### PR TITLE
BAC-4928: TF Provider support for wildcard server workload hosts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6 # v6.x
+        uses: golangci/golangci-lint-action@v8 # v8.x
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,26 +1,34 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
+version: "2"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+    - swaggo
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - durationcheck
     - errcheck
     - forcetypeassert
     - godot
-    - gofmt
-    - gosimple
     - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
-    - vet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,10 +11,7 @@ formatters:
   enable:
     - gci
     - gofmt
-    - gofumpt
-    - goimports
     - golines
-    - swaggo
 
 linters:
   default: none
@@ -32,3 +29,9 @@ linters:
     - unconvert
     - unparam
     - unused
+  exclusions:
+    rules:
+      # Exclusion for errcheck: Error return value of `resp.Body.Close` is not checked (errcheck)
+      # Reference: https://github.com/kisielk/errcheck/issues/101
+      - linters: ["errcheck"]
+        source: "^\\s*defer\\s+"

--- a/internal/provider/access_condition_data_source.go
+++ b/internal/provider/access_condition_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type accessConditionsDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *accessConditionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *accessConditionsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *accessConditionsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *accessConditionsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_access_conditions"
 }
 
 // Schema defines the schema for the resource.
-func (d *accessConditionsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *accessConditionsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages an accessCondition.",
 		Attributes: map[string]schema.Attribute{
@@ -76,7 +88,9 @@ func (d *accessConditionsDataSource) Schema(_ context.Context, _ datasource.Sche
 							Description: "Wiz Specific rules for the Access Condition.",
 							Computed:    true,
 							Attributes: map[string]schema.Attribute{
-								"max_last_seen":               schema.Int64Attribute{Required: true},
+								"max_last_seen": schema.Int64Attribute{
+									Required: true,
+								},
 								"container_cluster_connected": schema.BoolAttribute{Required: true},
 							},
 						},
@@ -157,7 +171,11 @@ func (d *accessConditionsDataSource) Schema(_ context.Context, _ datasource.Sche
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *accessConditionsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *accessConditionsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.AccessConditionsDataSourceModel
 
 	accessConditions, err := d.client.GetAccessConditions(nil)
@@ -171,7 +189,11 @@ func (d *accessConditionsDataSource) Read(ctx context.Context, req datasource.Re
 
 	// Map response body to model
 	for _, accessCondition := range accessConditions {
-		accessConditionState := convertAccessConditionDTOToModel(ctx, accessCondition, models.AccessConditionResourceModel{})
+		accessConditionState := convertAccessConditionDTOToModel(
+			ctx,
+			accessCondition,
+			models.AccessConditionResourceModel{},
+		)
 		state.AccessConditions = append(state.AccessConditions, accessConditionState)
 	}
 

--- a/internal/provider/access_conditions_data_source_test.go
+++ b/internal/provider/access_conditions_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testAccessConditionsDataSource string = "data.aembit_access_conditions.test"
-const testAccessConditionResource string = "aembit_access_condition.crowdstrike"
+const (
+	testAccessConditionsDataSource string = "data.aembit_access_conditions.test"
+	testAccessConditionResource    string = "aembit_access_condition.crowdstrike"
+)
 
 func testFindAccessCondition(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -30,7 +32,11 @@ func testFindAccessCondition(resourceName string) resource.TestCheckFunc {
 
 func TestAccAccessConditionsDataSource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/condition/data/TestAccAccessConditionsDataSource.tf")
-	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "TF Acceptance Crowdstrike")
+	createFileConfig, _, _ := randomizeFileConfigs(
+		string(createFile),
+		"",
+		"TF Acceptance Crowdstrike",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -40,7 +46,10 @@ func TestAccAccessConditionsDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Access Conditions returned
-					resource.TestCheckResourceAttrSet(testAccessConditionsDataSource, "access_conditions.#"),
+					resource.TestCheckResourceAttrSet(
+						testAccessConditionsDataSource,
+						"access_conditions.#",
+					),
 					// Find newly created entry
 					testFindAccessCondition(testAccessConditionResource),
 				),

--- a/internal/provider/access_conditions_resource.go
+++ b/internal/provider/access_conditions_resource.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
@@ -15,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -35,17 +35,29 @@ type accessConditionResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *accessConditionResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *accessConditionResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_access_condition"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *accessConditionResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *accessConditionResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *accessConditionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *accessConditionResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -191,7 +203,11 @@ func (r *accessConditionResource) ConfigValidators(_ context.Context) []resource
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *accessConditionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *accessConditionResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.AccessConditionResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -232,7 +248,11 @@ func (r *accessConditionResource) Create(ctx context.Context, req resource.Creat
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *accessConditionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *accessConditionResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.AccessConditionResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -267,7 +287,11 @@ func (r *accessConditionResource) Read(ctx context.Context, req resource.ReadReq
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *accessConditionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *accessConditionResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.AccessConditionResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -319,7 +343,11 @@ func (r *accessConditionResource) Update(ctx context.Context, req resource.Updat
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *accessConditionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *accessConditionResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.AccessConditionResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -352,12 +380,21 @@ func (r *accessConditionResource) Delete(ctx context.Context, req resource.Delet
 }
 
 // Imports an existing resource by passing externalId.
-func (r *accessConditionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *accessConditionResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertAccessConditionModelToDTO(ctx context.Context, model models.AccessConditionResourceModel, externalID *string, client *aembit.CloudClient) (aembit.AccessConditionDTO, error) {
+func convertAccessConditionModelToDTO(
+	ctx context.Context,
+	model models.AccessConditionResourceModel,
+	externalID *string,
+	client *aembit.CloudClient,
+) (aembit.AccessConditionDTO, error) {
 	var accessCondition aembit.AccessConditionDTO
 	accessCondition.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -365,7 +402,7 @@ func convertAccessConditionModelToDTO(ctx context.Context, model models.AccessCo
 		IsActive:    model.IsActive.ValueBool(),
 	}
 	if externalID != nil {
-		accessCondition.EntityDTO.ExternalID = *externalID
+		accessCondition.ExternalID = *externalID
 	}
 
 	if len(model.Tags.Elements()) > 0 {
@@ -398,12 +435,18 @@ func convertAccessConditionModelToDTO(ctx context.Context, model models.AccessCo
 		for _, location := range model.GeoIp.Locations {
 			countryCodeInput := location.CountryCode.ValueString()
 
-			countryIndex := slices.IndexFunc(countriesResource.Countries, func(c *countryResourceModel) bool {
-				return c.CountryCode.ValueString() == countryCodeInput
-			})
+			countryIndex := slices.IndexFunc(
+				countriesResource.Countries,
+				func(c *countryResourceModel) bool {
+					return c.CountryCode.ValueString() == countryCodeInput
+				},
+			)
 
 			if countryIndex == -1 {
-				return accessCondition, fmt.Errorf("%v is not a valid CountryCode", countryCodeInput)
+				return accessCondition, fmt.Errorf(
+					"%v is not a valid CountryCode",
+					countryCodeInput,
+				)
 			}
 
 			countryFound := countriesResource.Countries[countryIndex]
@@ -426,9 +469,12 @@ func convertAccessConditionModelToDTO(ctx context.Context, model models.AccessCo
 
 		timezoneInput := model.Time.Timezone.ValueString()
 
-		tsIndex := slices.IndexFunc(timezoneResource.Timezones, func(ts *timezoneResourceModel) bool {
-			return ts.Timezone.ValueString() == timezoneInput
-		})
+		tsIndex := slices.IndexFunc(
+			timezoneResource.Timezones,
+			func(ts *timezoneResourceModel) bool {
+				return ts.Timezone.ValueString() == timezoneInput
+			},
+		)
 
 		if tsIndex == -1 {
 			return accessCondition, fmt.Errorf("%v is not a valid timezone", timezoneInput)
@@ -444,32 +490,41 @@ func convertAccessConditionModelToDTO(ctx context.Context, model models.AccessCo
 
 		for _, schedule := range model.Time.Schedule {
 			ordinal, err := findOrdinal(schedule.Day.ValueString())
-
 			if err != nil {
 				return accessCondition, err
 			}
 
-			accessCondition.Conditions.Schedule = append(accessCondition.Conditions.Schedule, aembit.ScheduleDTO{
-				StartTime: schedule.StartTime.ValueString(),
-				EndTime:   schedule.EndTime.ValueString(),
-				WeekDay: &aembit.WeekDayDTO{
-					Name:    schedule.Day.ValueString(),
-					Ordinal: ordinal,
+			accessCondition.Conditions.Schedule = append(
+				accessCondition.Conditions.Schedule,
+				aembit.ScheduleDTO{
+					StartTime: schedule.StartTime.ValueString(),
+					EndTime:   schedule.EndTime.ValueString(),
+					WeekDay: &aembit.WeekDayDTO{
+						Name:    schedule.Day.ValueString(),
+						Ordinal: ordinal,
+					},
 				},
-			})
+			)
 		}
 	}
 
 	return accessCondition, nil
 }
 
-func FillSubdivisions(loc *aembit.CountryDTO, subDivisions []*models.GeoIpSubdivisionModel, countryFound *countryResourceModel) error {
+func FillSubdivisions(
+	loc *aembit.CountryDTO,
+	subDivisions []*models.GeoIpSubdivisionModel,
+	countryFound *countryResourceModel,
+) error {
 	for _, subDivision := range subDivisions {
 		subDivisionInput := subDivision.SubdivisionCode.ValueString()
 
-		subDivisionIndex := slices.IndexFunc(countryFound.Subdivisions, func(s *countrySubdivisionResourceModel) bool {
-			return s.SubdivisionCode.ValueString() == subDivisionInput
-		})
+		subDivisionIndex := slices.IndexFunc(
+			countryFound.Subdivisions,
+			func(s *countrySubdivisionResourceModel) bool {
+				return s.SubdivisionCode.ValueString() == subDivisionInput
+			},
+		)
 
 		if subDivisionIndex == -1 {
 			return fmt.Errorf("%v is not a valid SubdivisionCode", subDivisionInput)
@@ -487,13 +542,17 @@ func FillSubdivisions(loc *aembit.CountryDTO, subDivisions []*models.GeoIpSubdiv
 	return nil
 }
 
-func convertAccessConditionDTOToModel(ctx context.Context, dto aembit.AccessConditionDTO, _ models.AccessConditionResourceModel) models.AccessConditionResourceModel {
+func convertAccessConditionDTOToModel(
+	ctx context.Context,
+	dto aembit.AccessConditionDTO,
+	_ models.AccessConditionResourceModel,
+) models.AccessConditionResourceModel {
 	var model models.AccessConditionResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 
 	if len(dto.IntegrationID) == 0 {
 		model.IntegrationID = types.StringValue(dto.Integration.ExternalID)
@@ -508,10 +567,12 @@ func convertAccessConditionDTOToModel(ctx context.Context, dto aembit.AccessCond
 		}
 	case "CrowdStrike":
 		model.CrowdStrike = &models.AccessConditionCrowdstrikeModel{
-			MaxLastSeen:                        types.Int64Value(dto.Conditions.MaxLastSeenSeconds),
-			MatchHostname:                      types.BoolValue(dto.Conditions.MatchHostname),
-			MatchSerialNumber:                  types.BoolValue(dto.Conditions.MatchSerialNumber),
-			PreventRestrictedFunctionalityMode: types.BoolValue(dto.Conditions.PreventRestrictedFunctionalityMode),
+			MaxLastSeen:       types.Int64Value(dto.Conditions.MaxLastSeenSeconds),
+			MatchHostname:     types.BoolValue(dto.Conditions.MatchHostname),
+			MatchSerialNumber: types.BoolValue(dto.Conditions.MatchSerialNumber),
+			PreventRestrictedFunctionalityMode: types.BoolValue(
+				dto.Conditions.PreventRestrictedFunctionalityMode,
+			),
 		}
 	case "AembitGeoIPCondition":
 		geoIpModel := models.AccessConditionGeoIpModel{}

--- a/internal/provider/access_conditions_resource_test.go
+++ b/internal/provider/access_conditions_resource_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testAccessConditionResourceWiz string = "aembit_access_condition.wiz"
-const testAccessConditionResourceCrowdstrike string = "aembit_access_condition.crowdstrike"
-const testAccessConditionResourceGeoIp string = "aembit_access_condition.geoip"
-const testAccessConditionResourceTimeZone string = "aembit_access_condition.timezone"
+const (
+	testAccessConditionResourceWiz         string = "aembit_access_condition.wiz"
+	testAccessConditionResourceCrowdstrike string = "aembit_access_condition.crowdstrike"
+	testAccessConditionResourceGeoIp       string = "aembit_access_condition.geoip"
+	testAccessConditionResourceTimeZone    string = "aembit_access_condition.timezone"
+)
 
 func testDeleteAccessCondition(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -42,7 +44,11 @@ func TestAccAccessConditionResource_Wiz(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify AccessCondition Name
-					resource.TestCheckResourceAttr(testAccessConditionResourceWiz, "name", "TF Acceptance Wiz"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceWiz,
+						"name",
+						"TF Acceptance Wiz",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testAccessConditionResourceWiz, "id"),
 					// Verify placeholder ID is set
@@ -50,17 +56,29 @@ func TestAccAccessConditionResource_Wiz(t *testing.T) {
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteAccessCondition(testAccessConditionResourceWiz), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteAccessCondition(testAccessConditionResourceWiz),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
-			{ResourceName: testAccessConditionResourceWiz, ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      testAccessConditionResourceWiz,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testAccessConditionResourceWiz, "name", "TF Acceptance Wiz - Modified"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceWiz,
+						"name",
+						"TF Acceptance Wiz - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -69,8 +87,12 @@ func TestAccAccessConditionResource_Wiz(t *testing.T) {
 }
 
 func TestAccAccessConditionResource_Crowdstrike(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/condition/crowdstrike/TestAccAccessConditionResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/condition/crowdstrike/TestAccAccessConditionResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/condition/crowdstrike/TestAccAccessConditionResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/condition/crowdstrike/TestAccAccessConditionResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -80,11 +102,27 @@ func TestAccAccessConditionResource_Crowdstrike(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify AccessCondition Name
-					resource.TestCheckResourceAttr(testAccessConditionResourceCrowdstrike, "name", "TF Acceptance Crowdstrike"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceCrowdstrike,
+						"name",
+						"TF Acceptance Crowdstrike",
+					),
 					// Verify Tags.
-					resource.TestCheckResourceAttr(testAccessConditionResourceCrowdstrike, tagsCount, "2"),
-					resource.TestCheckResourceAttr(testAccessConditionResourceCrowdstrike, tagsColor, "blue"),
-					resource.TestCheckResourceAttr(testAccessConditionResourceCrowdstrike, tagsDay, "Sunday"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceCrowdstrike,
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceCrowdstrike,
+						tagsColor,
+						"blue",
+					),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceCrowdstrike,
+						tagsDay,
+						"Sunday",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testAccessConditionResourceCrowdstrike, "id"),
 					// Verify placeholder ID is set
@@ -92,13 +130,21 @@ func TestAccAccessConditionResource_Crowdstrike(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: testAccessConditionResourceCrowdstrike, ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      testAccessConditionResourceCrowdstrike,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testAccessConditionResourceCrowdstrike, "name", "TF Acceptance Crowdstrike - Modified"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceCrowdstrike,
+						"name",
+						"TF Acceptance Crowdstrike - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -118,11 +164,27 @@ func TestAccAccessConditionResource_GeoIp(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify AccessCondition Name
-					resource.TestCheckResourceAttr(testAccessConditionResourceGeoIp, "name", "TF Acceptance GeoIp"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceGeoIp,
+						"name",
+						"TF Acceptance GeoIp",
+					),
 					// Verify Tags.
-					resource.TestCheckResourceAttr(testAccessConditionResourceGeoIp, tagsCount, "2"),
-					resource.TestCheckResourceAttr(testAccessConditionResourceGeoIp, tagsColor, "blue"),
-					resource.TestCheckResourceAttr(testAccessConditionResourceGeoIp, tagsDay, "Sunday"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceGeoIp,
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceGeoIp,
+						tagsColor,
+						"blue",
+					),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceGeoIp,
+						tagsDay,
+						"Sunday",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testAccessConditionResourceGeoIp, "id"),
 					// Verify placeholder ID is set
@@ -130,13 +192,21 @@ func TestAccAccessConditionResource_GeoIp(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: testAccessConditionResourceGeoIp, ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      testAccessConditionResourceGeoIp,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testAccessConditionResourceGeoIp, "name", "TF Acceptance GeoIp - Modified"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceGeoIp,
+						"name",
+						"TF Acceptance GeoIp - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -146,7 +216,9 @@ func TestAccAccessConditionResource_GeoIp(t *testing.T) {
 
 func TestAccAccessConditionResource_TimeZone(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/condition/timezone/TestAccAccessConditionResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/condition/timezone/TestAccAccessConditionResource.tfmod")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/condition/timezone/TestAccAccessConditionResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -156,11 +228,27 @@ func TestAccAccessConditionResource_TimeZone(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify AccessCondition Name
-					resource.TestCheckResourceAttr(testAccessConditionResourceTimeZone, "name", "TF Acceptance Timezone"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceTimeZone,
+						"name",
+						"TF Acceptance Timezone",
+					),
 					// Verify Tags.
-					resource.TestCheckResourceAttr(testAccessConditionResourceTimeZone, tagsCount, "2"),
-					resource.TestCheckResourceAttr(testAccessConditionResourceTimeZone, tagsColor, "blue"),
-					resource.TestCheckResourceAttr(testAccessConditionResourceTimeZone, tagsDay, "Sunday"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceTimeZone,
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceTimeZone,
+						tagsColor,
+						"blue",
+					),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceTimeZone,
+						tagsDay,
+						"Sunday",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testAccessConditionResourceTimeZone, "id"),
 					// Verify placeholder ID is set
@@ -168,13 +256,21 @@ func TestAccAccessConditionResource_TimeZone(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: testAccessConditionResourceTimeZone, ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      testAccessConditionResourceTimeZone,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testAccessConditionResourceTimeZone, "name", "TF Acceptance Timezone - Modified"),
+					resource.TestCheckResourceAttr(
+						testAccessConditionResourceTimeZone,
+						"name",
+						"TF Acceptance Timezone - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/access_policies_data_source.go
+++ b/internal/provider/access_policies_data_source.go
@@ -3,12 +3,11 @@ package provider
 import (
 	"context"
 
-	"terraform-provider-aembit/internal/provider/models"
-
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -28,17 +27,29 @@ type accessPoliciesDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *accessPoliciesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *accessPoliciesDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *accessPoliciesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *accessPoliciesDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_access_policies"
 }
 
 // Schema defines the schema for the resource.
-func (d *accessPoliciesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *accessPoliciesDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages access policies.",
 		Attributes: map[string]schema.Attribute{
@@ -134,7 +145,11 @@ func (d *accessPoliciesDataSource) Schema(_ context.Context, _ datasource.Schema
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *accessPoliciesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *accessPoliciesDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.AccessPoliciesDataSourceModel
 
 	accessPolicies, err := d.client.GetAccessPoliciesV2(nil)
@@ -149,7 +164,10 @@ func (d *accessPoliciesDataSource) Read(ctx context.Context, req datasource.Read
 	// Map response body to model
 	for _, accessPolicy := range accessPolicies {
 		// fetch mappings values individually
-		credentialMappings, err, _ := d.client.GetAccessPolicyV2CredentialMappings(accessPolicy.ExternalID, nil)
+		credentialMappings, err, _ := d.client.GetAccessPolicyV2CredentialMappings(
+			accessPolicy.ExternalID,
+			nil,
+		)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error retrieving credential mappings",

--- a/internal/provider/access_policies_data_source_test.go
+++ b/internal/provider/access_policies_data_source_test.go
@@ -16,7 +16,11 @@ func TestAccAccessPoliciesDataSource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/policy/data/TestAccAccessPoliciesDataSource.tf")
 
 	randID := rand.Intn(10000000)
-	createFileConfig := strings.ReplaceAll(string(createFile), "clientworkloadNamespace", fmt.Sprintf("clientworkloadNamespace%d", randID))
+	createFileConfig := strings.ReplaceAll(
+		string(createFile),
+		"clientworkloadNamespace",
+		fmt.Sprintf("clientworkloadNamespace%d", randID),
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -26,15 +30,27 @@ func TestAccAccessPoliciesDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify number of Access Policies returned
-					resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.#"),
+					resource.TestCheckResourceAttrSet(
+						testAccessPoliciesDataSource,
+						"access_policies.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.id"),
-					resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.client_workload"),
+					resource.TestCheckResourceAttrSet(
+						testAccessPoliciesDataSource,
+						"access_policies.0.id",
+					),
+					resource.TestCheckResourceAttrSet(
+						testAccessPoliciesDataSource,
+						"access_policies.0.client_workload",
+					),
 					// Commented out as access policies can be created without trust provider(s)/access condition(s)/credential provider(s)
-					//resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.trust_providers.#"),
-					//resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.access_conditions.#"),
-					//resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.credential_provider"),
-					resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.server_workload"),
+					// resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.trust_providers.#"),
+					// resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.access_conditions.#"),
+					// resource.TestCheckResourceAttrSet(testAccessPoliciesDataSource, "access_policies.0.credential_provider"),
+					resource.TestCheckResourceAttrSet(
+						testAccessPoliciesDataSource,
+						"access_policies.0.server_workload",
+					),
 				),
 			},
 		},

--- a/internal/provider/access_policy_resource_test.go
+++ b/internal/provider/access_policy_resource_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-const AccessPolicyPathFirst string = "aembit_access_policy.first_policy"
-const AccessPolicyPathSecond string = "aembit_access_policy.second_policy"
-const AccessPolicyPathMultiCPFirst string = "aembit_access_policy.multi_cp_first_policy"
-const AccessPolicyPathMultiCPSecond string = "aembit_access_policy.multi_cp_second_policy"
-const CredentialProvidersCount string = "credential_providers.#"
+const (
+	AccessPolicyPathFirst         string = "aembit_access_policy.first_policy"
+	AccessPolicyPathSecond        string = "aembit_access_policy.second_policy"
+	AccessPolicyPathMultiCPFirst  string = "aembit_access_policy.multi_cp_first_policy"
+	AccessPolicyPathMultiCPSecond string = "aembit_access_policy.multi_cp_second_policy"
+	CredentialProvidersCount      string = "credential_providers.#"
+)
 
 var accessPolicyChecks = []resource.TestCheckFunc{
 	// Verify values for First Policy.
@@ -25,7 +27,11 @@ var accessPolicyChecks = []resource.TestCheckFunc{
 func TestAccAccessPolicyResource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/policy/TestAccAccessPolicyResource.tf")
 	modifyFile, _ := os.ReadFile("../../tests/policy/TestAccAccessPolicyResource.tfmod")
-	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(string(createFile), string(modifyFile), "clientworkloadNamespace")
+	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"clientworkloadNamespace",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -69,8 +75,16 @@ var basicAccessPolicyChecks = []resource.TestCheckFunc{
 func TestAccBasicAccessPolicyResource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/policy/TestAccBasicAccessPolicyResource.tf")
 	modifyFile, _ := os.ReadFile("../../tests/policy/TestAccBasicAccessPolicyResource.tfmod")
-	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(string(createFile), string(modifyFile), "clientworkloadNamespace")
-	createFileConfig, modifyFileConfig, _ = randomizeFileConfigs(createFileConfig, modifyFileConfig, "secondClientWorkloadNamespace")
+	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"clientworkloadNamespace",
+	)
+	createFileConfig, modifyFileConfig, _ = randomizeFileConfigs(
+		createFileConfig,
+		modifyFileConfig,
+		"secondClientWorkloadNamespace",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -79,9 +93,18 @@ func TestAccBasicAccessPolicyResource(t *testing.T) {
 			{
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					append(basicAccessPolicyChecks,
-						resource.TestCheckResourceAttr(AccessPolicyPathFirst, "name", "TF First Policy"),
-						resource.TestCheckResourceAttr(AccessPolicyPathSecond, "name", "TF Second Policy"),
+					append(
+						basicAccessPolicyChecks,
+						resource.TestCheckResourceAttr(
+							AccessPolicyPathFirst,
+							"name",
+							"TF First Policy",
+						),
+						resource.TestCheckResourceAttr(
+							AccessPolicyPathSecond,
+							"name",
+							"TF Second Policy",
+						),
 					)...,
 				),
 			},
@@ -91,9 +114,18 @@ func TestAccBasicAccessPolicyResource(t *testing.T) {
 			{
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					append(basicAccessPolicyChecks,
-						resource.TestCheckResourceAttr(AccessPolicyPathFirst, "name", "Placeholder"),
-						resource.TestCheckResourceAttr(AccessPolicyPathSecond, "name", "Placeholder"),
+					append(
+						basicAccessPolicyChecks,
+						resource.TestCheckResourceAttr(
+							AccessPolicyPathFirst,
+							"name",
+							"Placeholder",
+						),
+						resource.TestCheckResourceAttr(
+							AccessPolicyPathSecond,
+							"name",
+							"Placeholder",
+						),
 					)...,
 				),
 			},
@@ -105,8 +137,16 @@ func TestAccBasicAccessPolicyResource(t *testing.T) {
 func TestAccMultipleCredentialProviders_AccessPolicyResource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/policy/TestAccMultipleCPAccessPolicyResource.tf")
 	modifyFile, _ := os.ReadFile("../../tests/policy/TestAccMultipleCPAccessPolicyResource.tfmod")
-	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(string(createFile), string(modifyFile), "clientworkloadNamespace")
-	createFileConfig, modifyFileConfig, _ = randomizeFileConfigs(createFileConfig, modifyFileConfig, "secondClientWorkloadNamespace")
+	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"clientworkloadNamespace",
+	)
+	createFileConfig, modifyFileConfig, _ = randomizeFileConfigs(
+		createFileConfig,
+		modifyFileConfig,
+		"secondClientWorkloadNamespace",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -115,24 +155,60 @@ func TestAccMultipleCredentialProviders_AccessPolicyResource(t *testing.T) {
 			{
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPFirst, "name", "TF Multi CP First Policy"),
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPFirst, CredentialProvidersCount, "2"),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPFirst,
+						"name",
+						"TF Multi CP First Policy",
+					),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPFirst,
+						CredentialProvidersCount,
+						"2",
+					),
 
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPSecond, "name", "TF Multi CP Second Policy"),
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPSecond, CredentialProvidersCount, "3"),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPSecond,
+						"name",
+						"TF Multi CP Second Policy",
+					),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPSecond,
+						CredentialProvidersCount,
+						"3",
+					),
 				),
 			},
 			// ImportState testing
-			{ResourceName: AccessPolicyPathMultiCPFirst, ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      AccessPolicyPathMultiCPFirst,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPFirst, "name", "TF Multi CP First Policy Updated"),
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPFirst, CredentialProvidersCount, "2"),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPFirst,
+						"name",
+						"TF Multi CP First Policy Updated",
+					),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPFirst,
+						CredentialProvidersCount,
+						"2",
+					),
 
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPSecond, "name", "TF Multi CP Second Policy Updated"),
-					resource.TestCheckResourceAttr(AccessPolicyPathMultiCPSecond, CredentialProvidersCount, "2"),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPSecond,
+						"name",
+						"TF Multi CP Second Policy Updated",
+					),
+					resource.TestCheckResourceAttr(
+						AccessPolicyPathMultiCPSecond,
+						CredentialProvidersCount,
+						"2",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -142,14 +218,20 @@ func TestAccMultipleCredentialProviders_AccessPolicyResource(t *testing.T) {
 
 func TestAccMultipleCPAccessPolicyResource_ErrorDuplicateMappings_Create(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/policy/TestAccAccessPolicyDuplicateMappings.tf")
-	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "clientworkloadNamespace")
+	createFileConfig, _, _ := randomizeFileConfigs(
+		string(createFile),
+		"",
+		"clientworkloadNamespace",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      createFileConfig,
-				ExpectError: regexp.MustCompile(`duplicate credential provider mapping already exists`),
+				Config: createFileConfig,
+				ExpectError: regexp.MustCompile(
+					`duplicate credential provider mapping already exists`,
+				),
 			},
 		},
 	})

--- a/internal/provider/agent_controller_device_code_data_source.go
+++ b/internal/provider/agent_controller_device_code_data_source.go
@@ -3,12 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -28,7 +28,11 @@ type agentControllerDeviceCodeDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *agentControllerDeviceCodeDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *agentControllerDeviceCodeDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	if req.ProviderData == nil {
 		return
 	}
@@ -37,7 +41,10 @@ func (d *agentControllerDeviceCodeDataSource) Configure(_ context.Context, req d
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *aembit.CloudClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf(
+				"Expected *aembit.CloudClient, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData,
+			),
 		)
 
 		return
@@ -47,12 +54,20 @@ func (d *agentControllerDeviceCodeDataSource) Configure(_ context.Context, req d
 }
 
 // Metadata returns the data source type name.
-func (d *agentControllerDeviceCodeDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *agentControllerDeviceCodeDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_agent_controller_device_code"
 }
 
 // Schema defines the schema for the resource.
-func (d *agentControllerDeviceCodeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *agentControllerDeviceCodeDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Generates an agent controller device code.",
 		Attributes: map[string]schema.Attribute{
@@ -69,7 +84,11 @@ func (d *agentControllerDeviceCodeDataSource) Schema(_ context.Context, _ dataso
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *agentControllerDeviceCodeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *agentControllerDeviceCodeDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var deviceCodeRequest models.AgentControllerDeviceCodeDataSourceModel
 	var state models.AgentControllerDeviceCodeDataSourceModel
 

--- a/internal/provider/agent_controller_device_code_data_source_test.go
+++ b/internal/provider/agent_controller_device_code_data_source_test.go
@@ -20,7 +20,10 @@ func TestAccAgentControllerDeviceCodeDataSource(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testAgentControllerDeviceCodeDataSource, "device_code"),
+					resource.TestCheckResourceAttrSet(
+						testAgentControllerDeviceCodeDataSource,
+						"device_code",
+					),
 				),
 			},
 		},

--- a/internal/provider/agent_controller_resource.go
+++ b/internal/provider/agent_controller_resource.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -31,17 +31,29 @@ type agentControllerResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *agentControllerResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *agentControllerResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_agent_controller"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *agentControllerResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *agentControllerResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *agentControllerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *agentControllerResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -91,7 +103,11 @@ func (r *agentControllerResource) Schema(_ context.Context, _ resource.SchemaReq
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *agentControllerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *agentControllerResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.AgentControllerResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -101,7 +117,7 @@ func (r *agentControllerResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	// Generate API request body from plan
-	var controller aembit.AgentControllerDTO = convertAgentControllerModelToDTO(ctx, plan, nil)
+	controller := convertAgentControllerModelToDTO(ctx, plan, nil)
 
 	// Create new Agent Controller
 	agentController, err := r.client.CreateAgentController(controller, nil)
@@ -125,7 +141,11 @@ func (r *agentControllerResource) Create(ctx context.Context, req resource.Creat
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *agentControllerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *agentControllerResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.AgentControllerResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -160,7 +180,11 @@ func (r *agentControllerResource) Read(ctx context.Context, req resource.ReadReq
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *agentControllerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *agentControllerResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.AgentControllerResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -181,7 +205,7 @@ func (r *agentControllerResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// Generate API request body from plan
-	var controller aembit.AgentControllerDTO = convertAgentControllerModelToDTO(ctx, plan, &externalID)
+	controller := convertAgentControllerModelToDTO(ctx, plan, &externalID)
 
 	// Update Agent Controller
 	agentController, err := r.client.UpdateAgentController(controller, nil)
@@ -205,7 +229,11 @@ func (r *agentControllerResource) Update(ctx context.Context, req resource.Updat
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *agentControllerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *agentControllerResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.AgentControllerResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -238,12 +266,20 @@ func (r *agentControllerResource) Delete(ctx context.Context, req resource.Delet
 }
 
 // Imports an existing resource by passing externalId.
-func (r *agentControllerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *agentControllerResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertAgentControllerModelToDTO(ctx context.Context, model models.AgentControllerResourceModel, externalID *string) aembit.AgentControllerDTO {
+func convertAgentControllerModelToDTO(
+	ctx context.Context,
+	model models.AgentControllerResourceModel,
+	externalID *string,
+) aembit.AgentControllerDTO {
 	var controller aembit.AgentControllerDTO
 	controller.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -262,7 +298,7 @@ func convertAgentControllerModelToDTO(ctx context.Context, model models.AgentCon
 		}
 	}
 	if externalID != nil {
-		controller.EntityDTO.ExternalID = *externalID
+		controller.ExternalID = *externalID
 	}
 	controller.TrustProviderID = model.TrustProviderID.ValueString()
 	controller.AllowedTLSHostname = model.AllowedTLSHostname.ValueString()
@@ -270,19 +306,22 @@ func convertAgentControllerModelToDTO(ctx context.Context, model models.AgentCon
 	return controller
 }
 
-func convertAgentControllerDTOToModel(ctx context.Context, dto aembit.AgentControllerDTO) models.AgentControllerResourceModel {
+func convertAgentControllerDTOToModel(
+	ctx context.Context,
+	dto aembit.AgentControllerDTO,
+) models.AgentControllerResourceModel {
 	var model models.AgentControllerResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
 	if len(dto.TrustProviderID) > 0 {
 		model.TrustProviderID = types.StringValue(dto.TrustProviderID)
 	} else {
 		model.TrustProviderID = types.StringNull()
 	}
 	model.AllowedTLSHostname = types.StringValue(dto.AllowedTLSHostname)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 
 	return model
 }

--- a/internal/provider/agent_controller_resource_test.go
+++ b/internal/provider/agent_controller_resource_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testAgentControllerAzure string = "aembit_agent_controller.azure_tp"
-const testAgentControllerDeviceCode string = "aembit_agent_controller.device_code"
+const (
+	testAgentControllerAzure      string = "aembit_agent_controller.azure_tp"
+	testAgentControllerDeviceCode string = "aembit_agent_controller.device_code"
+)
 
 func testDeleteAgentController(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -31,7 +33,9 @@ func testDeleteAgentController(resourceName string) resource.TestCheckFunc {
 
 func TestAccAgentControllerResources(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/agent_controllers/TestAccAgentControllerResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/agent_controllers/TestAccAgentControllerResource.tfmod")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/agent_controllers/TestAccAgentControllerResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -41,8 +45,16 @@ func TestAccAgentControllerResources(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(testAgentControllerAzure, "name", "TF Acceptance Azure Trust Provider"),
-					resource.TestCheckResourceAttr(testAgentControllerDeviceCode, "name", "TF Acceptance Device Code"),
+					resource.TestCheckResourceAttr(
+						testAgentControllerAzure,
+						"name",
+						"TF Acceptance Azure Trust Provider",
+					),
+					resource.TestCheckResourceAttr(
+						testAgentControllerDeviceCode,
+						"name",
+						"TF Acceptance Device Code",
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testAgentControllerAzure, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testAgentControllerAzure, tagsColor, "blue"),
@@ -55,7 +67,11 @@ func TestAccAgentControllerResources(t *testing.T) {
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteAgentController(testAgentControllerAzure), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteAgentController(testAgentControllerAzure),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
@@ -65,8 +81,16 @@ func TestAccAgentControllerResources(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testAgentControllerAzure, "name", "TF Acceptance Azure Trust Provider - Modified"),
-					resource.TestCheckResourceAttr(testAgentControllerDeviceCode, "name", "TF Acceptance Device Code - Modified"),
+					resource.TestCheckResourceAttr(
+						testAgentControllerAzure,
+						"name",
+						"TF Acceptance Azure Trust Provider - Modified",
+					),
+					resource.TestCheckResourceAttr(
+						testAgentControllerDeviceCode,
+						"name",
+						"TF Acceptance Device Code - Modified",
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testAgentControllerAzure, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testAgentControllerAzure, tagsColor, "orange"),
@@ -79,15 +103,19 @@ func TestAccAgentControllerResources(t *testing.T) {
 }
 
 func TestAccAgentControllerResource_Validation(t *testing.T) {
-	emptyNameFile, _ := os.ReadFile("../../tests/agent_controllers/TestAccAgentControllerResource.tfempty")
+	emptyNameFile, _ := os.ReadFile(
+		"../../tests/agent_controllers/TestAccAgentControllerResource.tfempty",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config:      string(emptyNameFile),
-				ExpectError: regexp.MustCompile(`Attribute name string length must be between 1 and 128`),
+				Config: string(emptyNameFile),
+				ExpectError: regexp.MustCompile(
+					`Attribute name string length must be between 1 and 128`,
+				),
 			},
 		},
 	})

--- a/internal/provider/agent_controllers_data_source.go
+++ b/internal/provider/agent_controllers_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type agentControllersDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *agentControllersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *agentControllersDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *agentControllersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *agentControllersDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_agent_controllers"
 }
 
 // Schema defines the schema for the resource.
-func (d *agentControllersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *agentControllersDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages an agent controller.",
 		Attributes: map[string]schema.Attribute{
@@ -84,7 +96,11 @@ func (d *agentControllersDataSource) Schema(_ context.Context, _ datasource.Sche
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *agentControllersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *agentControllersDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.AgentControllersDataSourceModel
 
 	agentControllers, err := d.client.GetAgentControllers(nil)

--- a/internal/provider/agent_controllers_data_source_test.go
+++ b/internal/provider/agent_controllers_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testAgentControllersDataSource string = "data.aembit_agent_controllers.test"
-const testAgentControllerResource string = "aembit_agent_controller.azure_tp"
+const (
+	testAgentControllersDataSource string = "data.aembit_agent_controllers.test"
+	testAgentControllerResource    string = "aembit_agent_controller.azure_tp"
+)
 
 func testFindAgentController(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -29,8 +31,14 @@ func testFindAgentController(resourceName string) resource.TestCheckFunc {
 }
 
 func TestAccAgentControllersDataSource(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/agent_controllers/data/TestAccAgentControllersDataSource.tf")
-	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "TF Acceptance Azure Trust Provider")
+	createFile, _ := os.ReadFile(
+		"../../tests/agent_controllers/data/TestAccAgentControllersDataSource.tf",
+	)
+	createFileConfig, _, _ := randomizeFileConfigs(
+		string(createFile),
+		"",
+		"TF Acceptance Azure Trust Provider",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -40,9 +48,15 @@ func TestAccAgentControllersDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Agent Controllers returned
-					resource.TestCheckResourceAttrSet(testAgentControllersDataSource, "agent_controllers.#"),
+					resource.TestCheckResourceAttrSet(
+						testAgentControllersDataSource,
+						"agent_controllers.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testAgentControllersDataSource, "agent_controllers.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testAgentControllersDataSource,
+						"agent_controllers.0.id",
+					),
 					// Find newly created entry
 					testFindAgentController(testAgentControllerResource),
 				),

--- a/internal/provider/client_workload_resource.go
+++ b/internal/provider/client_workload_resource.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -14,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -34,17 +34,29 @@ type clientWorkloadResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *clientWorkloadResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *clientWorkloadResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_client_workload"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *clientWorkloadResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *clientWorkloadResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *clientWorkloadResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *clientWorkloadResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -174,7 +186,11 @@ func (r *clientWorkloadResource) Schema(_ context.Context, _ resource.SchemaRequ
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *clientWorkloadResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *clientWorkloadResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.ClientWorkloadResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -184,7 +200,7 @@ func (r *clientWorkloadResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Generate API request body from plan
-	var workload aembit.ClientWorkloadExternalDTO = convertClientWorkloadModelToDTO(ctx, plan, nil)
+	workload := convertClientWorkloadModelToDTO(ctx, plan, nil)
 
 	// Create new Client Workload
 	clientWorkload, err := r.client.CreateClientWorkload(workload, nil)
@@ -208,7 +224,11 @@ func (r *clientWorkloadResource) Create(ctx context.Context, req resource.Create
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *clientWorkloadResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *clientWorkloadResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.ClientWorkloadResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -244,7 +264,11 @@ func (r *clientWorkloadResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *clientWorkloadResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *clientWorkloadResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.ClientWorkloadResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -254,7 +278,7 @@ func (r *clientWorkloadResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Extract external ID from state
-	var externalID string = state.ID.ValueString()
+	externalID := state.ID.ValueString()
 
 	// Retrieve values from plan
 	var plan models.ClientWorkloadResourceModel
@@ -265,7 +289,7 @@ func (r *clientWorkloadResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Generate API request body from plan
-	var workload aembit.ClientWorkloadExternalDTO = convertClientWorkloadModelToDTO(ctx, plan, &externalID)
+	workload := convertClientWorkloadModelToDTO(ctx, plan, &externalID)
 
 	// Update Client Workload
 	clientWorkload, err := r.client.UpdateClientWorkload(workload, nil)
@@ -289,7 +313,11 @@ func (r *clientWorkloadResource) Update(ctx context.Context, req resource.Update
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *clientWorkloadResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *clientWorkloadResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.ClientWorkloadResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -322,12 +350,20 @@ func (r *clientWorkloadResource) Delete(ctx context.Context, req resource.Delete
 }
 
 // Imports an existing resource by passing externalId.
-func (r *clientWorkloadResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *clientWorkloadResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertClientWorkloadModelToDTO(ctx context.Context, model models.ClientWorkloadResourceModel, externalID *string) aembit.ClientWorkloadExternalDTO {
+func convertClientWorkloadModelToDTO(
+	ctx context.Context,
+	model models.ClientWorkloadResourceModel,
+	externalID *string,
+) aembit.ClientWorkloadExternalDTO {
 	var workload aembit.ClientWorkloadExternalDTO
 	workload.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -361,7 +397,7 @@ func convertClientWorkloadModelToDTO(ctx context.Context, model models.ClientWor
 	}
 
 	if externalID != nil {
-		workload.EntityDTO.ExternalID = *externalID
+		workload.ExternalID = *externalID
 	}
 
 	workload.StandaloneCertificateAuthority = model.StandaloneCertificateAuthority.ValueString()
@@ -369,14 +405,17 @@ func convertClientWorkloadModelToDTO(ctx context.Context, model models.ClientWor
 	return workload
 }
 
-func convertClientWorkloadDTOToModel(ctx context.Context, dto aembit.ClientWorkloadExternalDTO) models.ClientWorkloadResourceModel {
+func convertClientWorkloadDTOToModel(
+	ctx context.Context,
+	dto aembit.ClientWorkloadExternalDTO,
+) models.ClientWorkloadResourceModel {
 	var model models.ClientWorkloadResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
 	model.Identities = newClientWorkloadIdentityModel(ctx, dto.Identities)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 	if dto.StandaloneCertificateAuthority == "" {
 		model.StandaloneCertificateAuthority = types.StringNull()
 	} else {
@@ -386,7 +425,10 @@ func convertClientWorkloadDTOToModel(ctx context.Context, dto aembit.ClientWorkl
 	return model
 }
 
-func newClientWorkloadIdentityModel(ctx context.Context, clientWorkloadIdentities []aembit.ClientWorkloadIdentityDTO) types.Set {
+func newClientWorkloadIdentityModel(
+	ctx context.Context,
+	clientWorkloadIdentities []aembit.ClientWorkloadIdentityDTO,
+) types.Set {
 	identities := make([]models.IdentitiesModel, len(clientWorkloadIdentities))
 
 	for i, identity := range clientWorkloadIdentities {

--- a/internal/provider/client_workload_resource_test.go
+++ b/internal/provider/client_workload_resource_test.go
@@ -11,12 +11,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testCWResource string = "aembit_client_workload.test"
-const testCWResourceDescription string = "Acceptance Test client workload"
-const testCWResourceIdentitiesCount string = "identities.#"
+const (
+	testCWResource                string = "aembit_client_workload.test"
+	testCWResourceDescription     string = "Acceptance Test client workload"
+	testCWResourceIdentitiesCount string = "identities.#"
+)
 
-var testCWResourceIdentitiesType = []string{"identities.0.type", "identities.1.type", "identities.2.type", "identities.3.type"}
-var testCWResourceIdentitiesValue = []string{"identities.0.value", "identities.1.value", "identities.2.value", "identities.3.value"}
+var (
+	testCWResourceIdentitiesType = []string{
+		"identities.0.type",
+		"identities.1.type",
+		"identities.2.type",
+		"identities.3.type",
+	}
+	testCWResourceIdentitiesValue = []string{
+		"identities.0.value",
+		"identities.1.value",
+		"identities.2.value",
+		"identities.3.value",
+	}
+)
 
 func testDeleteClientWorkload() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -35,8 +49,14 @@ func testDeleteClientWorkload() resource.TestCheckFunc {
 
 func TestAccClientWorkloadResource_k8sNamespace(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/client/k8sNamespace/TestAccClientWorkloadResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/client/k8sNamespace/TestAccClientWorkloadResource.tfmod")
-	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(string(createFile), string(modifyFile), "unittest1namespace")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/client/k8sNamespace/TestAccClientWorkloadResource.tfmod",
+	)
+	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"unittest1namespace",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -47,12 +67,28 @@ func TestAccClientWorkloadResource_k8sNamespace(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Client Workload Name, Description, Active status
 					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1"),
-					resource.TestCheckResourceAttr(testCWResource, "description", testCWResourceDescription),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"description",
+						testCWResourceDescription,
+					),
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "false"),
 					// Verify Workload Identity.
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesCount, "1"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[0], "k8sNamespace"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[0], newName),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesCount,
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[0],
+						"k8sNamespace",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[0],
+						newName,
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testCWResource, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testCWResource, tagsColor, "blue"),
@@ -72,7 +108,11 @@ func TestAccClientWorkloadResource_k8sNamespace(t *testing.T) {
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - modified"),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"name",
+						"Unit Test 1 - modified",
+					),
 					// Verify active state updated.
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "true"),
 					// Verify Tags.
@@ -88,9 +128,19 @@ func TestAccClientWorkloadResource_k8sNamespace(t *testing.T) {
 
 func TestAccClientWorkloadResource_k8sPodName(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/client/k8sPodName/TestAccClientWorkloadResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/client/k8sPodName/TestAccClientWorkloadResource.tfmod")
-	createFileConfig, modifyFileConfig, newNamePod1 := randomizeFileConfigs(string(createFile), string(modifyFile), "unittest1podname1")
-	createFileConfig, modifyFileConfig, newNamePod2 := randomizeFileConfigs(createFileConfig, modifyFileConfig, "unittest1podname2")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/client/k8sPodName/TestAccClientWorkloadResource.tfmod",
+	)
+	createFileConfig, modifyFileConfig, newNamePod1 := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"unittest1podname1",
+	)
+	createFileConfig, modifyFileConfig, newNamePod2 := randomizeFileConfigs(
+		createFileConfig,
+		modifyFileConfig,
+		"unittest1podname2",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -100,15 +150,43 @@ func TestAccClientWorkloadResource_k8sPodName(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Client Workload Name, Description, Active status
-					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - In Resource Set"),
-					resource.TestCheckResourceAttr(testCWResource, "description", testCWResourceDescription),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"name",
+						"Unit Test 1 - In Resource Set",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"description",
+						testCWResourceDescription,
+					),
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "false"),
 					// Verify Workload Identity.
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesCount, "2"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[0], "k8sPodName"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[0], newNamePod1),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[1], "k8sPodName"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[1], newNamePod2),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[0],
+						"k8sPodName",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[0],
+						newNamePod1,
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[1],
+						"k8sPodName",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[1],
+						newNamePod2,
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testCWResource, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testCWResource, tagsColor, "blue"),
@@ -124,7 +202,11 @@ func TestAccClientWorkloadResource_k8sPodName(t *testing.T) {
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - In Resource Set - modified"),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"name",
+						"Unit Test 1 - In Resource Set - modified",
+					),
 					// Verify active state updated.
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "true"),
 					// Verify Tags.
@@ -142,8 +224,14 @@ func TestAccClientWorkloadResource_k8sPodName(t *testing.T) {
 func TestAccClientWorkloadResource_k8sPodName_CustomResourceSetAuth(t *testing.T) {
 	skipNotCI(t)
 
-	createFile, _ := os.ReadFile("../../tests/client/resourceSet/TestAccClientWorkloadCustomResourceSet.tf")
-	createFileConfig, _, newName := randomizeFileConfigs(string(createFile), "", "custom-resource-set")
+	createFile, _ := os.ReadFile(
+		"../../tests/client/resourceSet/TestAccClientWorkloadCustomResourceSet.tf",
+	)
+	createFileConfig, _, newName := randomizeFileConfigs(
+		string(createFile),
+		"",
+		"custom-resource-set",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -156,9 +244,21 @@ func TestAccClientWorkloadResource_k8sPodName_CustomResourceSetAuth(t *testing.T
 					resource.TestCheckResourceAttr(testCWResource, "name", "TF Acceptance RS"),
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "false"),
 					// Verify Workload Identity.
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesCount, "1"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[0], "k8sPodName"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[0], newName),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesCount,
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[0],
+						"k8sPodName",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[0],
+						newName,
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testCWResource, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testCWResource, tagsColor, "blue"),
@@ -176,8 +276,14 @@ func TestAccClientWorkloadResource_k8sPodName_CustomResourceSetAuth(t *testing.T
 
 func TestAccClientWorkloadResource_AwsLambdaArn(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/client/awsLambdaArn/TestAccClientWorkloadResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/client/awsLambdaArn/TestAccClientWorkloadResource.tfmod")
-	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(string(createFile), string(modifyFile), "arn:aws:lambda:us-east-1:880961858887:function:helloworld")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/client/awsLambdaArn/TestAccClientWorkloadResource.tfmod",
+	)
+	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"arn:aws:lambda:us-east-1:880961858887:function:helloworld",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -187,13 +293,33 @@ func TestAccClientWorkloadResource_AwsLambdaArn(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Client Workload Name, Description, Active status
-					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - awsLambdaArn"),
-					resource.TestCheckResourceAttr(testCWResource, "description", testCWResourceDescription),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"name",
+						"Unit Test 1 - awsLambdaArn",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"description",
+						testCWResourceDescription,
+					),
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "false"),
 					// Verify Workload Identity.
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesCount, "1"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[0], "awsLambdaArn"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[0], newName),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesCount,
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[0],
+						"awsLambdaArn",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[0],
+						newName,
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testCWResource, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testCWResource, tagsColor, "blue"),
@@ -209,7 +335,11 @@ func TestAccClientWorkloadResource_AwsLambdaArn(t *testing.T) {
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - awsLambdaArn - modified"),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"name",
+						"Unit Test 1 - awsLambdaArn - modified",
+					),
 					// Verify active state updated.
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "true"),
 					// Verify Tags.
@@ -226,7 +356,11 @@ func TestAccClientWorkloadResource_AwsLambdaArn(t *testing.T) {
 func TestAccClientWorkloadResource_GitLabJob(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/client/gitLabJob/TestAccClientWorkloadResource.tf")
 	modifyFile, _ := os.ReadFile("../../tests/client/gitLabJob/TestAccClientWorkloadResource.tfmod")
-	createFileConfig, modifyFileConfig, newSubject := randomizeFileConfigs(string(createFile), string(modifyFile), "subject")
+	createFileConfig, modifyFileConfig, newSubject := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"subject",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -236,19 +370,63 @@ func TestAccClientWorkloadResource_GitLabJob(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Client Workload Name, Description, Active status
-					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - gitLabJob"),
-					resource.TestCheckResourceAttr(testCWResource, "description", testCWResourceDescription),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"name",
+						"Unit Test 1 - gitLabJob",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"description",
+						testCWResourceDescription,
+					),
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "false"),
 					// Verify Workload Identity.
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesCount, "4"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[0], "gitlabIdTokenNamespacePath"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[0], "namespacePath"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[1], "gitlabIdTokenProjectPath"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[1], "projectPath"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[2], "gitlabIdTokenRefPath"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[2], "refPath"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[3], "gitlabIdTokenSubject"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[3], newSubject),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesCount,
+						"4",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[0],
+						"gitlabIdTokenNamespacePath",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[0],
+						"namespacePath",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[1],
+						"gitlabIdTokenProjectPath",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[1],
+						"projectPath",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[2],
+						"gitlabIdTokenRefPath",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[2],
+						"refPath",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[3],
+						"gitlabIdTokenSubject",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[3],
+						newSubject,
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testCWResource, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testCWResource, tagsColor, "blue"),
@@ -264,7 +442,11 @@ func TestAccClientWorkloadResource_GitLabJob(t *testing.T) {
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - gitLabJob - modified"),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						"name",
+						"Unit Test 1 - gitLabJob - modified",
+					),
 					// Verify active state updated.
 					resource.TestCheckResourceAttr(testCWResource, "is_active", "true"),
 					// Verify Tags.
@@ -279,7 +461,9 @@ func TestAccClientWorkloadResource_GitLabJob(t *testing.T) {
 }
 
 func TestAccClientWorkloadResource_StandaloneCA(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/client/standalone-certificate-authority/TestAccClientWorkloadStandaloneCertificateAuthority.tf")
+	createFile, _ := os.ReadFile(
+		"../../tests/client/standalone-certificate-authority/TestAccClientWorkloadStandaloneCertificateAuthority.tf",
+	)
 	createFileConfig, _, newName := randomizeFileConfigs(string(createFile), "", "unittestname")
 
 	resource.Test(t, resource.TestCase{
@@ -297,12 +481,27 @@ func TestAccClientWorkloadResource_StandaloneCA(t *testing.T) {
 					resource.TestCheckResourceAttr(testCWResource, tagsColor, "blue"),
 					resource.TestCheckResourceAttr(testCWResource, tagsDay, "Sunday"),
 					// Verify Workload Identity.
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesCount, "1"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[0], "k8sPodName"),
-					resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[0], newName),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesCount,
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesType[0],
+						"k8sPodName",
+					),
+					resource.TestCheckResourceAttr(
+						testCWResource,
+						testCWResourceIdentitiesValue[0],
+						newName,
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testCWResource, "id"),
-					resource.TestCheckResourceAttrSet(testCWResource, "standalone_certificate_authority"),
+					resource.TestCheckResourceAttrSet(
+						testCWResource,
+						"standalone_certificate_authority",
+					),
 				),
 			},
 			// ImportState testing
@@ -324,16 +523,36 @@ var clientWorkloadIdentifierTests = []struct {
 }
 
 func TestAccClientWorkloadResource_Miscellaneous(t *testing.T) {
-	createFileConfigWithPlaceholders, _ := os.ReadFile("../../tests/client/miscellaneous/TestAccClientWorkloadResource.tf")
-	modifyFileConfigWithPlaceholders, _ := os.ReadFile("../../tests/client/miscellaneous/TestAccClientWorkloadResource.tfmod")
+	createFileConfigWithPlaceholders, _ := os.ReadFile(
+		"../../tests/client/miscellaneous/TestAccClientWorkloadResource.tf",
+	)
+	modifyFileConfigWithPlaceholders, _ := os.ReadFile(
+		"../../tests/client/miscellaneous/TestAccClientWorkloadResource.tfmod",
+	)
 
 	for _, test := range clientWorkloadIdentifierTests {
 
-		createFileConfig := strings.ReplaceAll(string(createFileConfigWithPlaceholders), "IDENTITY_TYPE_PLACEHOLDER", test.identityType)
-		createFileConfig = strings.ReplaceAll(createFileConfig, "IDENTITY_VALUE_PLACEHOLDER", test.identityValue)
+		createFileConfig := strings.ReplaceAll(
+			string(createFileConfigWithPlaceholders),
+			"IDENTITY_TYPE_PLACEHOLDER",
+			test.identityType,
+		)
+		createFileConfig = strings.ReplaceAll(
+			createFileConfig,
+			"IDENTITY_VALUE_PLACEHOLDER",
+			test.identityValue,
+		)
 
-		modifyFileConfig := strings.ReplaceAll(string(modifyFileConfigWithPlaceholders), "IDENTITY_TYPE_PLACEHOLDER", test.identityType)
-		modifyFileConfig = strings.ReplaceAll(modifyFileConfig, "IDENTITY_VALUE_PLACEHOLDER", test.identityValue)
+		modifyFileConfig := strings.ReplaceAll(
+			string(modifyFileConfigWithPlaceholders),
+			"IDENTITY_TYPE_PLACEHOLDER",
+			test.identityType,
+		)
+		modifyFileConfig = strings.ReplaceAll(
+			modifyFileConfig,
+			"IDENTITY_VALUE_PLACEHOLDER",
+			test.identityValue,
+		)
 
 		resource.Test(t, resource.TestCase{
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -343,13 +562,33 @@ func TestAccClientWorkloadResource_Miscellaneous(t *testing.T) {
 					Config: createFileConfig,
 					Check: resource.ComposeAggregateTestCheckFunc(
 						// Verify Client Workload Name, Description, Active status
-						resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - miscellaneous"),
-						resource.TestCheckResourceAttr(testCWResource, "description", testCWResourceDescription),
+						resource.TestCheckResourceAttr(
+							testCWResource,
+							"name",
+							"Unit Test 1 - miscellaneous",
+						),
+						resource.TestCheckResourceAttr(
+							testCWResource,
+							"description",
+							testCWResourceDescription,
+						),
 						resource.TestCheckResourceAttr(testCWResource, "is_active", "false"),
 						// Verify Workload Identity.
-						resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesCount, "1"),
-						resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesType[0], test.identityType),
-						resource.TestCheckResourceAttr(testCWResource, testCWResourceIdentitiesValue[0], test.identityValue),
+						resource.TestCheckResourceAttr(
+							testCWResource,
+							testCWResourceIdentitiesCount,
+							"1",
+						),
+						resource.TestCheckResourceAttr(
+							testCWResource,
+							testCWResourceIdentitiesType[0],
+							test.identityType,
+						),
+						resource.TestCheckResourceAttr(
+							testCWResource,
+							testCWResourceIdentitiesValue[0],
+							test.identityValue,
+						),
 						// Verify Tags.
 						resource.TestCheckResourceAttr(testCWResource, tagsCount, "2"),
 						resource.TestCheckResourceAttr(testCWResource, tagsColor, "blue"),
@@ -365,7 +604,11 @@ func TestAccClientWorkloadResource_Miscellaneous(t *testing.T) {
 					Config: modifyFileConfig,
 					Check: resource.ComposeAggregateTestCheckFunc(
 						// Verify Name updated
-						resource.TestCheckResourceAttr(testCWResource, "name", "Unit Test 1 - miscellaneous - modified"),
+						resource.TestCheckResourceAttr(
+							testCWResource,
+							"name",
+							"Unit Test 1 - miscellaneous - modified",
+						),
 						// Verify active state updated.
 						resource.TestCheckResourceAttr(testCWResource, "is_active", "true"),
 						// Verify Tags.

--- a/internal/provider/client_workloads_data_source.go
+++ b/internal/provider/client_workloads_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type clientWorkloadsDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *clientWorkloadsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *clientWorkloadsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *clientWorkloadsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *clientWorkloadsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_client_workloads"
 }
 
 // Schema defines the schema for the resource.
-func (r *clientWorkloadsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (r *clientWorkloadsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages client workloads.",
 		Attributes: map[string]schema.Attribute{
@@ -97,7 +109,11 @@ func (r *clientWorkloadsDataSource) Schema(_ context.Context, _ datasource.Schem
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *clientWorkloadsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *clientWorkloadsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.ClientWorkloadsDataSourceModel
 
 	clientWorkloads, err := d.client.GetClientWorkloads(nil)

--- a/internal/provider/client_workloads_data_source_test.go
+++ b/internal/provider/client_workloads_data_source_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testClientWorkloadsDataSource string = "data.aembit_client_workloads.test"
-const testClientWorkloadResource string = "aembit_client_workload.test"
+const (
+	testClientWorkloadsDataSource string = "data.aembit_client_workloads.test"
+	testClientWorkloadResource    string = "aembit_client_workload.test"
+)
 
 func testFindClientWorkload(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -35,8 +37,16 @@ func TestAccClientWorkloadsDataSource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/client/data/TestAccClientWorkloadsDataSource.tf")
 
 	randID := rand.Intn(10000000)
-	createFileConfig := strings.ReplaceAll(string(createFile), "unittest1namespace", fmt.Sprintf("unittest1namespace%d", randID))
-	createFileConfig, _, _ = randomizeFileConfigs(createFileConfig, "", "Acceptance Test client workload")
+	createFileConfig := strings.ReplaceAll(
+		string(createFile),
+		"unittest1namespace",
+		fmt.Sprintf("unittest1namespace%d", randID),
+	)
+	createFileConfig, _, _ = randomizeFileConfigs(
+		createFileConfig,
+		"",
+		"Acceptance Test client workload",
+	)
 	createFileConfig, _, _ = randomizeFileConfigs(createFileConfig, "", "unittestname")
 
 	resource.Test(t, resource.TestCase{
@@ -47,9 +57,15 @@ func TestAccClientWorkloadsDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Client Workloads returned
-					resource.TestCheckResourceAttrSet(testClientWorkloadsDataSource, "client_workloads.#"),
+					resource.TestCheckResourceAttrSet(
+						testClientWorkloadsDataSource,
+						"client_workloads.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testClientWorkloadsDataSource, "client_workloads.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testClientWorkloadsDataSource,
+						"client_workloads.0.id",
+					),
 					// Find newly created entry
 					testFindClientWorkload(testClientWorkloadResource),
 				),

--- a/internal/provider/common_helpers.go
+++ b/internal/provider/common_helpers.go
@@ -53,7 +53,6 @@ func skipNotCI(t *testing.T) {
 func getTerraformVersion() string {
 	cmd := exec.Command("terraform", "version")
 	output, err := cmd.Output()
-
 	if err != nil {
 		fmt.Printf("Error executing command: %v\n", err)
 		return "v1.6" // return the lowest version if something goes wrong

--- a/internal/provider/country_data_source.go
+++ b/internal/provider/country_data_source.go
@@ -26,17 +26,29 @@ type countriesDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *countriesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *countriesDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *countriesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *countriesDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_countries"
 }
 
 // Schema defines the schema for the resource.
-func (d *countriesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *countriesDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "List of countries and their administrative subdivisions.",
 		Attributes: map[string]schema.Attribute{
@@ -81,7 +93,11 @@ func (d *countriesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *countriesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *countriesDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	state := GetCountries(d.client)
 	// Set state
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/credential_provider_integration_resource.go
+++ b/internal/provider/credential_provider_integration_resource.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -31,17 +31,29 @@ type credentialProviderIntegrationResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *credentialProviderIntegrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *credentialProviderIntegrationResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_credential_provider_integration"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *credentialProviderIntegrationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *credentialProviderIntegrationResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *credentialProviderIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *credentialProviderIntegrationResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -87,7 +99,11 @@ func (r *credentialProviderIntegrationResource) Schema(_ context.Context, _ reso
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *credentialProviderIntegrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *credentialProviderIntegrationResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.CredentialProviderIntegrationResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -97,7 +113,7 @@ func (r *credentialProviderIntegrationResource) Create(ctx context.Context, req 
 	}
 
 	// Generate API request body from plan
-	var dto aembit.CredentialProviderIntegrationDTO = convertCredentialProviderIntegrationModelToDTO(plan, nil)
+	dto := convertCredentialProviderIntegrationModelToDTO(plan, nil)
 
 	// Create new Integration
 	credentialIntegration, err := r.client.CreateCredentialProviderIntegration(dto, nil)
@@ -121,7 +137,11 @@ func (r *credentialProviderIntegrationResource) Create(ctx context.Context, req 
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *credentialProviderIntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *credentialProviderIntegrationResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.CredentialProviderIntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -131,7 +151,10 @@ func (r *credentialProviderIntegrationResource) Read(ctx context.Context, req re
 	}
 
 	// Get refreshed trust value from Aembit
-	credentialIntegration, err, notFound := r.client.GetCredentialProviderIntegration(state.ID.ValueString(), nil)
+	credentialIntegration, err, notFound := r.client.GetCredentialProviderIntegration(
+		state.ID.ValueString(),
+		nil,
+	)
 	if err != nil {
 		resp.Diagnostics.AddWarning(
 			"Error reading Aembit Credential Provider Integration",
@@ -156,7 +179,11 @@ func (r *credentialProviderIntegrationResource) Read(ctx context.Context, req re
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *credentialProviderIntegrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *credentialProviderIntegrationResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.CredentialProviderIntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -177,7 +204,7 @@ func (r *credentialProviderIntegrationResource) Update(ctx context.Context, req 
 	}
 
 	// Generate API request body from plan
-	var dto aembit.CredentialProviderIntegrationDTO = convertCredentialProviderIntegrationModelToDTO(plan, &externalID)
+	dto := convertCredentialProviderIntegrationModelToDTO(plan, &externalID)
 
 	// Update Credential Provider Integration
 	credentialIntegration, err := r.client.UpdateCredentialProviderIntegration(dto, nil)
@@ -201,7 +228,11 @@ func (r *credentialProviderIntegrationResource) Update(ctx context.Context, req 
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *credentialProviderIntegrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *credentialProviderIntegrationResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.CredentialProviderIntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -222,12 +253,19 @@ func (r *credentialProviderIntegrationResource) Delete(ctx context.Context, req 
 }
 
 // Imports an existing resource by passing externalId.
-func (r *credentialProviderIntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *credentialProviderIntegrationResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertCredentialProviderIntegrationModelToDTO(model models.CredentialProviderIntegrationResourceModel, externalID *string) aembit.CredentialProviderIntegrationDTO {
+func convertCredentialProviderIntegrationModelToDTO(
+	model models.CredentialProviderIntegrationResourceModel,
+	externalID *string,
+) aembit.CredentialProviderIntegrationDTO {
 	var credentialIntegration aembit.CredentialProviderIntegrationDTO
 	credentialIntegration.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -235,7 +273,7 @@ func convertCredentialProviderIntegrationModelToDTO(model models.CredentialProvi
 	}
 
 	if externalID != nil {
-		credentialIntegration.EntityDTO.ExternalID = *externalID
+		credentialIntegration.ExternalID = *externalID
 	}
 
 	credentialIntegration.Type = "GitLab"
@@ -245,11 +283,14 @@ func convertCredentialProviderIntegrationModelToDTO(model models.CredentialProvi
 	return credentialIntegration
 }
 
-func convertCredentialProviderIntegrationDTOToModel(dto aembit.CredentialProviderIntegrationDTO, state models.CredentialProviderIntegrationResourceModel) models.CredentialProviderIntegrationResourceModel {
+func convertCredentialProviderIntegrationDTOToModel(
+	dto aembit.CredentialProviderIntegrationDTO,
+	state models.CredentialProviderIntegrationResourceModel,
+) models.CredentialProviderIntegrationResourceModel {
 	var model models.CredentialProviderIntegrationResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
 
 	model.GitLab = &models.CredentialProviderIntegrationGitlabModel{
 		Url:                 types.StringValue(dto.Url),

--- a/internal/provider/credential_provider_integration_resource_test.go
+++ b/internal/provider/credential_provider_integration_resource_test.go
@@ -30,8 +30,12 @@ func testDeleteCredentialProviderIntegration(resourceName string) resource.TestC
 func TestAccCredentialProviderIntegrationResource_GitLab(t *testing.T) {
 	t.Skip("skipping test until we figure out a way to handle the GitLab tokens appropriately")
 
-	createFile, _ := os.ReadFile("../../tests/credential_provider_integration/gitlab/TestAccCredentialProviderIntegrationResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential_provider_integration/gitlab/TestAccCredentialProviderIntegrationResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential_provider_integration/gitlab/TestAccCredentialProviderIntegrationResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential_provider_integration/gitlab/TestAccCredentialProviderIntegrationResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -41,25 +45,49 @@ func TestAccCredentialProviderIntegrationResource_GitLab(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Integration Name
-					resource.TestCheckResourceAttr(testCredentialProviderIntegrationGitLab, "name", "TF Acceptance GitLab Credential Integration"),
+					resource.TestCheckResourceAttr(
+						testCredentialProviderIntegrationGitLab,
+						"name",
+						"TF Acceptance GitLab Credential Integration",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testCredentialProviderIntegrationGitLab, "id"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProviderIntegrationGitLab,
+						"id",
+					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet(testCredentialProviderIntegrationGitLab, "id"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProviderIntegrationGitLab,
+						"id",
+					),
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteCredentialProviderIntegration(testCredentialProviderIntegrationGitLab), ExpectNonEmptyPlan: true},
+			{
+				Config: string(createFile),
+				Check: testDeleteCredentialProviderIntegration(
+					testCredentialProviderIntegrationGitLab,
+				),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
-			{ResourceName: testCredentialProviderIntegrationGitLab, ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      testCredentialProviderIntegrationGitLab,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testCredentialProviderIntegrationGitLab, "name", "TF Acceptance GitLab Credential Integration - Modified"),
+					resource.TestCheckResourceAttr(
+						testCredentialProviderIntegrationGitLab,
+						"name",
+						"TF Acceptance GitLab Credential Integration - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/credential_provider_integrations_data_source.go
+++ b/internal/provider/credential_provider_integrations_data_source.go
@@ -2,11 +2,11 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -26,17 +26,29 @@ type credentialProviderIntegrationsDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *credentialProviderIntegrationsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *credentialProviderIntegrationsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *credentialProviderIntegrationsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *credentialProviderIntegrationsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_credential_provider_integrations"
 }
 
 // Schema defines the schema for the resource.
-func (d *credentialProviderIntegrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *credentialProviderIntegrationsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages a credential provider integration.",
 		Attributes: map[string]schema.Attribute{
@@ -81,13 +93,16 @@ func (d *credentialProviderIntegrationsDataSource) Schema(_ context.Context, _ d
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *credentialProviderIntegrationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *credentialProviderIntegrationsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.CredentialProviderIntegrationsDataSourceModel
 
 	req.Config.Get(ctx, &state)
 
 	integrations, err := d.client.GetCredentialProviderIntegrations(nil)
-
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Aembit Credential Provider Integrations",
@@ -98,9 +113,15 @@ func (d *credentialProviderIntegrationsDataSource) Read(ctx context.Context, req
 
 	// Map response body to model
 	for _, integration := range integrations {
-		integrationState := convertCredentialProviderIntegrationDTOToModel(integration, models.CredentialProviderIntegrationResourceModel{})
+		integrationState := convertCredentialProviderIntegrationDTOToModel(
+			integration,
+			models.CredentialProviderIntegrationResourceModel{},
+		)
 
-		state.CredentialProviderIntegrations = append(state.CredentialProviderIntegrations, integrationState)
+		state.CredentialProviderIntegrations = append(
+			state.CredentialProviderIntegrations,
+			integrationState,
+		)
 	}
 
 	// Set state

--- a/internal/provider/credential_provider_integrations_data_source_test.go
+++ b/internal/provider/credential_provider_integrations_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testCredentialProviderIntegrationsDataSource string = "data.aembit_credential_provider_integrations.test"
-const testCredentialProviderIntegrationResource string = "aembit_credential_provider_integration.gitlab"
+const (
+	testCredentialProviderIntegrationsDataSource string = "data.aembit_credential_provider_integrations.test"
+	testCredentialProviderIntegrationResource    string = "aembit_credential_provider_integration.gitlab"
+)
 
 func testFindCredentialProviderIntegration(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -31,8 +33,14 @@ func testFindCredentialProviderIntegration(resourceName string) resource.TestChe
 func TestAccCredentialProviderIntegrationsDataSource(t *testing.T) {
 	t.Skip("skipping test until we figure out a way to handle the GitLab tokens appropriately")
 
-	createFile, _ := os.ReadFile("../../tests/credential_provider_integration/data/TestAccCredentialProviderIntegrationsDataSource.tf")
-	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "TF Acceptance GitLab Credential Integration")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential_provider_integration/data/TestAccCredentialProviderIntegrationsDataSource.tf",
+	)
+	createFileConfig, _, _ := randomizeFileConfigs(
+		string(createFile),
+		"",
+		"TF Acceptance GitLab Credential Integration",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -42,11 +50,19 @@ func TestAccCredentialProviderIntegrationsDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Integrations returned
-					resource.TestCheckResourceAttrSet(testCredentialProviderIntegrationsDataSource, "credential_provider_integrations.#"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProviderIntegrationsDataSource,
+						"credential_provider_integrations.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testCredentialProviderIntegrationsDataSource, "credential_provider_integrations.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProviderIntegrationsDataSource,
+						"credential_provider_integrations.0.id",
+					),
 					// Find newly created entry
-					testFindCredentialProviderIntegration(testCredentialProviderIntegrationResource),
+					testFindCredentialProviderIntegration(
+						testCredentialProviderIntegrationResource,
+					),
 				),
 			},
 		},

--- a/internal/provider/credential_provider_resource.go
+++ b/internal/provider/credential_provider_resource.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 	"time"
 
 	"aembit.io/aembit"
@@ -25,6 +23,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -47,17 +47,29 @@ type credentialProviderResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *credentialProviderResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *credentialProviderResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_credential_provider"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *credentialProviderResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *credentialProviderResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *credentialProviderResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *credentialProviderResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -273,11 +285,13 @@ func (r *credentialProviderResource) Schema(_ context.Context, _ resource.Schema
 						Description: "Set Custom Parameters for the OAuth Credential Provider.",
 						Optional:    true,
 						Computed:    true,
-						Default: setdefault.StaticValue(types.SetValueMust(types.ObjectType{AttrTypes: map[string]attr.Type{
-							"key":        types.StringType,
-							"value":      types.StringType,
-							"value_type": types.StringType,
-						}}, []attr.Value{})),
+						Default: setdefault.StaticValue(
+							types.SetValueMust(types.ObjectType{AttrTypes: map[string]attr.Type{
+								"key":        types.StringType,
+								"value":      types.StringType,
+								"value_type": types.StringType,
+							}}, []attr.Value{}),
+						),
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -344,11 +358,13 @@ func (r *credentialProviderResource) Schema(_ context.Context, _ resource.Schema
 						Description: "Set Custom Parameters for the OAuth Credential Provider.",
 						Optional:    true,
 						Computed:    true,
-						Default: setdefault.StaticValue(types.SetValueMust(types.ObjectType{AttrTypes: map[string]attr.Type{
-							"key":        types.StringType,
-							"value":      types.StringType,
-							"value_type": types.StringType,
-						}}, []attr.Value{})),
+						Default: setdefault.StaticValue(
+							types.SetValueMust(types.ObjectType{AttrTypes: map[string]attr.Type{
+								"key":        types.StringType,
+								"value":      types.StringType,
+								"value_type": types.StringType,
+							}}, []attr.Value{}),
+						),
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -672,7 +688,9 @@ func (r *credentialProviderResource) Schema(_ context.Context, _ resource.Schema
 }
 
 // Configure validators to ensure that only one Credential Provider type is specified.
-func (r *credentialProviderResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+func (r *credentialProviderResource) ConfigValidators(
+	_ context.Context,
+) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcevalidator.ExactlyOneOf(
 			path.MatchRoot("aembit_access_token"),
@@ -692,7 +710,11 @@ func (r *credentialProviderResource) ConfigValidators(_ context.Context) []resou
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *credentialProviderResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *credentialProviderResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.CredentialProviderResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -702,7 +724,13 @@ func (r *credentialProviderResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	// Generate API request body from plan
-	var credential aembit.CredentialProviderV2DTO = convertCredentialProviderModelToV2DTO(ctx, plan, nil, r.client.Tenant, r.client.StackDomain)
+	credential := convertCredentialProviderModelToV2DTO(
+		ctx,
+		plan,
+		nil,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Create new Credential Provider
 	credentialProvider, err := r.client.CreateCredentialProviderV2(credential, nil)
@@ -715,7 +743,13 @@ func (r *credentialProviderResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	// Map response body to schema and populate Computed attribute values
-	plan = convertCredentialProviderV2DTOToModel(ctx, *credentialProvider, plan, r.client.Tenant, r.client.StackDomain)
+	plan = convertCredentialProviderV2DTOToModel(
+		ctx,
+		*credentialProvider,
+		plan,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -726,7 +760,11 @@ func (r *credentialProviderResource) Create(ctx context.Context, req resource.Cr
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *credentialProviderResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *credentialProviderResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.CredentialProviderResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -736,7 +774,10 @@ func (r *credentialProviderResource) Read(ctx context.Context, req resource.Read
 	}
 
 	// Get refreshed credential value from Aembit
-	credentialProvider, err, notFound := r.client.GetCredentialProviderV2(state.ID.ValueString(), nil)
+	credentialProvider, err, notFound := r.client.GetCredentialProviderV2(
+		state.ID.ValueString(),
+		nil,
+	)
 	if err != nil {
 		resp.Diagnostics.AddWarning(
 			"Error reading Aembit Credential Provider",
@@ -750,7 +791,13 @@ func (r *credentialProviderResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	state = convertCredentialProviderV2DTOToModel(ctx, credentialProvider, state, r.client.Tenant, r.client.StackDomain)
+	state = convertCredentialProviderV2DTOToModel(
+		ctx,
+		credentialProvider,
+		state,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
@@ -761,7 +808,11 @@ func (r *credentialProviderResource) Read(ctx context.Context, req resource.Read
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *credentialProviderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *credentialProviderResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.CredentialProviderResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -771,7 +822,7 @@ func (r *credentialProviderResource) Update(ctx context.Context, req resource.Up
 	}
 
 	// Extract external ID from state
-	var externalID string = state.ID.ValueString()
+	externalID := state.ID.ValueString()
 
 	// Retrieve values from plan
 	var plan models.CredentialProviderResourceModel
@@ -782,7 +833,13 @@ func (r *credentialProviderResource) Update(ctx context.Context, req resource.Up
 	}
 
 	// Generate API request body from plan
-	var credential aembit.CredentialProviderV2DTO = convertCredentialProviderModelToV2DTO(ctx, plan, &externalID, r.client.Tenant, r.client.StackDomain)
+	credential := convertCredentialProviderModelToV2DTO(
+		ctx,
+		plan,
+		&externalID,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Update Credential Provider
 	credentialProvider, err := r.client.UpdateCredentialProviderV2(credential, nil)
@@ -795,7 +852,13 @@ func (r *credentialProviderResource) Update(ctx context.Context, req resource.Up
 	}
 
 	// Map response body to schema and populate Computed attribute values
-	plan = convertCredentialProviderV2DTOToModel(ctx, *credentialProvider, plan, r.client.Tenant, r.client.StackDomain)
+	plan = convertCredentialProviderV2DTOToModel(
+		ctx,
+		*credentialProvider,
+		plan,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -806,7 +869,11 @@ func (r *credentialProviderResource) Update(ctx context.Context, req resource.Up
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *credentialProviderResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *credentialProviderResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.CredentialProviderResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -839,12 +906,22 @@ func (r *credentialProviderResource) Delete(ctx context.Context, req resource.De
 }
 
 // Imports an existing resource by passing externalId.
-func (r *credentialProviderResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *credentialProviderResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.CredentialProviderResourceModel, externalID *string, tenantID string, stackDomain string) aembit.CredentialProviderV2DTO {
+func convertCredentialProviderModelToV2DTO(
+	ctx context.Context,
+	model models.CredentialProviderResourceModel,
+	externalID *string,
+	tenantID string,
+	stackDomain string,
+) aembit.CredentialProviderV2DTO {
 	var credential aembit.CredentialProviderV2DTO
 	credential.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -863,7 +940,7 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 		}
 	}
 	if externalID != nil {
-		credential.EntityDTO.ExternalID = *externalID
+		credential.ExternalID = *externalID
 	}
 
 	// Handle the Aembit Token use case
@@ -879,7 +956,9 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 	// Handle the API Key use case
 	if model.APIKey != nil {
 		credential.Type = "apikey"
-		credential.CredentialAPIKeyDTO = aembit.CredentialAPIKeyDTO{APIKey: model.APIKey.APIKey.ValueString()}
+		credential.CredentialAPIKeyDTO = aembit.CredentialAPIKeyDTO{
+			APIKey: model.APIKey.APIKey.ValueString(),
+		}
 	}
 
 	// Handle the AWS STS use case
@@ -917,8 +996,16 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 	// Handle the Snowflake JWT use case
 	if model.SnowflakeToken != nil {
 		credential.Type = "signed-jwt"
-		credential.Issuer = fmt.Sprintf("%s.%s.SHA256:{sha256(publicKey)}", model.SnowflakeToken.AccountID.ValueString(), model.SnowflakeToken.Username.ValueString())
-		credential.Subject = fmt.Sprintf("%s.%s", model.SnowflakeToken.AccountID.ValueString(), model.SnowflakeToken.Username.ValueString())
+		credential.Issuer = fmt.Sprintf(
+			"%s.%s.SHA256:{sha256(publicKey)}",
+			model.SnowflakeToken.AccountID.ValueString(),
+			model.SnowflakeToken.Username.ValueString(),
+		)
+		credential.Subject = fmt.Sprintf(
+			"%s.%s",
+			model.SnowflakeToken.AccountID.ValueString(),
+			model.SnowflakeToken.Username.ValueString(),
+		)
 		credential.Lifetime = 1
 		credential.AlgorithmType = "RS256"
 		credential.CredentialSnowflakeTokenV2DTO = aembit.CredentialSnowflakeTokenV2DTO{
@@ -956,7 +1043,7 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 			State:                model.OAuthAuthorizationCode.State.ValueString(),
 		}
 		if len(model.ID.ValueString()) > 0 {
-			credential.EntityDTO.ExternalID = model.ID.ValueString()
+			credential.ExternalID = model.ID.ValueString()
 		}
 
 		credential.LifetimeTimeSpanSeconds = model.OAuthAuthorizationCode.Lifetime
@@ -988,7 +1075,10 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 			ForwardingConfig:     model.VaultClientToken.VaultForwarding,
 			PrivateNetworkAccess: model.VaultClientToken.VaultPrivateNetworkAccess.ValueBool(),
 		}
-		credential.CustomClaims = make([]aembit.CustomClaimsDTO, len(model.VaultClientToken.CustomClaims))
+		credential.CustomClaims = make(
+			[]aembit.CustomClaimsDTO,
+			len(model.VaultClientToken.CustomClaims),
+		)
 		for i, claim := range model.VaultClientToken.CustomClaims {
 			credential.CustomClaims[i] = aembit.CustomClaimsDTO{
 				Key:       claim.Key,
@@ -1002,8 +1092,14 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 	if model.ManagedGitlabAccount != nil {
 		credential.Type = "gitlab-managed-account"
 		credential.Username = model.ManagedGitlabAccount.ServiceAccountUsername.ValueString()
-		credential.GroupIds = strings.Join(convertSetToSlice(model.ManagedGitlabAccount.GroupIds), ",")
-		credential.ProjectIds = strings.Join(convertSetToSlice(model.ManagedGitlabAccount.ProjectIds), ",")
+		credential.GroupIds = strings.Join(
+			convertSetToSlice(model.ManagedGitlabAccount.GroupIds),
+			",",
+		)
+		credential.ProjectIds = strings.Join(
+			convertSetToSlice(model.ManagedGitlabAccount.ProjectIds),
+			",",
+		)
 		credential.LifetimeInSeconds = model.ManagedGitlabAccount.LifetimeInHours.ValueInt32() * 3600
 		credential.AccessLevel = model.ManagedGitlabAccount.AccessLevel
 		credential.Scope = model.ManagedGitlabAccount.Scope
@@ -1020,7 +1116,10 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 		credential.Audience = model.OidcIdToken.Audience
 		credential.AlgorithmType = model.OidcIdToken.AlgorithmType
 
-		credential.CustomClaims = make([]aembit.CustomClaimsDTO, len(model.OidcIdToken.CustomClaims))
+		credential.CustomClaims = make(
+			[]aembit.CustomClaimsDTO,
+			len(model.OidcIdToken.CustomClaims),
+		)
 		for i, claim := range model.OidcIdToken.CustomClaims {
 			credential.CustomClaims[i] = aembit.CustomClaimsDTO{
 				Key:       claim.Key,
@@ -1033,13 +1132,18 @@ func convertCredentialProviderModelToV2DTO(ctx context.Context, model models.Cre
 	return credential
 }
 
-func convertCredentialProviderV2DTOToModel(ctx context.Context, dto aembit.CredentialProviderV2DTO, state models.CredentialProviderResourceModel, tenant, stackDomain string) models.CredentialProviderResourceModel {
+func convertCredentialProviderV2DTOToModel(
+	ctx context.Context,
+	dto aembit.CredentialProviderV2DTO,
+	state models.CredentialProviderResourceModel,
+	tenant, stackDomain string,
+) models.CredentialProviderResourceModel {
 	var model models.CredentialProviderResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 
 	// Set the objects to null to begin with
 	model.AembitToken = nil
@@ -1084,7 +1188,9 @@ func convertCredentialProviderV2DTOToModel(ctx context.Context, dto aembit.Crede
 }
 
 // convertAembitTokenV2DTOToModel converts the Aembit Token state object into a model ready for terraform processing.
-func convertAembitTokenV2DTOToModel(dto aembit.CredentialProviderV2DTO) *models.CredentialProviderAembitTokenModel {
+func convertAembitTokenV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+) *models.CredentialProviderAembitTokenModel {
 	// First, parse the credentialProvider.ProviderDetail JSON returned from Aembit Cloud
 	value := models.CredentialProviderAembitTokenModel{
 		Audience: types.StringValue(dto.Audience),
@@ -1096,7 +1202,10 @@ func convertAembitTokenV2DTOToModel(dto aembit.CredentialProviderV2DTO) *models.
 
 // convertAPIKeyV2DTOToModel converts the API Key state object into a model ready for terraform processing.
 // Note: Since Aembit vaults the API Key and does not return it in the API, the DTO will never contain the stored value.
-func convertAPIKeyV2DTOToModel(_ aembit.CredentialProviderV2DTO, state models.CredentialProviderResourceModel) *models.CredentialProviderAPIKeyModel {
+func convertAPIKeyV2DTOToModel(
+	_ aembit.CredentialProviderV2DTO,
+	state models.CredentialProviderResourceModel,
+) *models.CredentialProviderAPIKeyModel {
 	value := models.CredentialProviderAPIKeyModel{APIKey: types.StringNull()}
 	if state.APIKey != nil {
 		value.APIKey = state.APIKey.APIKey
@@ -1105,7 +1214,10 @@ func convertAPIKeyV2DTOToModel(_ aembit.CredentialProviderV2DTO, state models.Cr
 }
 
 // convertAwsSTSV2DTOToModel converts the AWS STS state object into a model ready for terraform processing.
-func convertAwsSTSV2DTOToModel(dto aembit.CredentialProviderV2DTO, tenant, stackDomain string) *models.CredentialProviderAwsSTSModel {
+func convertAwsSTSV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	tenant, stackDomain string,
+) *models.CredentialProviderAwsSTSModel {
 	value := models.CredentialProviderAwsSTSModel{
 		OIDCIssuer:    types.StringValue(fmt.Sprintf(oidcIssuerTemplate, tenant, stackDomain)),
 		TokenAudience: types.StringValue("sts.amazonaws.com"),
@@ -1116,7 +1228,10 @@ func convertAwsSTSV2DTOToModel(dto aembit.CredentialProviderV2DTO, tenant, stack
 }
 
 // convertGoogleWorkloadV2DTOToModel converts the Google Workload state object into a model ready for terraform processing.
-func convertGoogleWorkloadV2DTOToModel(dto aembit.CredentialProviderV2DTO, tenant, stackDomain string) *models.CredentialProviderGoogleWorkloadModel {
+func convertGoogleWorkloadV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	tenant, stackDomain string,
+) *models.CredentialProviderGoogleWorkloadModel {
 	value := models.CredentialProviderGoogleWorkloadModel{
 		OIDCIssuer:     types.StringValue(fmt.Sprintf(oidcIssuerTemplate, tenant, stackDomain)),
 		Audience:       types.StringValue(dto.Audience),
@@ -1127,7 +1242,10 @@ func convertGoogleWorkloadV2DTOToModel(dto aembit.CredentialProviderV2DTO, tenan
 }
 
 // convertAzureEntraWorkloadV2DTOTOModel converts the Azure Entra Workload state object into a model ready for terraform processing.
-func convertAzureEntraWorkloadV2DTOToModel(dto aembit.CredentialProviderV2DTO, tenant, stackDomain string) *models.CredentialProviderAzureEntraWorkloadModel {
+func convertAzureEntraWorkloadV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	tenant, stackDomain string,
+) *models.CredentialProviderAzureEntraWorkloadModel {
 	value := models.CredentialProviderAzureEntraWorkloadModel{
 		OIDCIssuer:  types.StringValue(fmt.Sprintf(oidcIssuerTemplate, tenant, stackDomain)),
 		Audience:    types.StringValue(dto.Audience),
@@ -1140,22 +1258,29 @@ func convertAzureEntraWorkloadV2DTOToModel(dto aembit.CredentialProviderV2DTO, t
 }
 
 // convertSnowflakeTokenV2DTOToModel converts the Snowflake JWT Token state object into a model ready for terraform processing.
-func convertSnowflakeTokenV2DTOToModel(dto aembit.CredentialProviderV2DTO) *models.CredentialProviderSnowflakeTokenModel {
+func convertSnowflakeTokenV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+) *models.CredentialProviderSnowflakeTokenModel {
 	acctData := strings.Split(dto.Subject, ".")
 	keyData := strings.ReplaceAll(dto.KeyContent, "\n", "")
 	keyData = strings.Replace(keyData, "-----BEGIN PUBLIC KEY-----", "", 1)
 	keyData = strings.Replace(keyData, "-----END PUBLIC KEY-----", "", 1)
 	value := models.CredentialProviderSnowflakeTokenModel{
-		AccountID:        types.StringValue(acctData[0]),
-		Username:         types.StringValue(acctData[1]),
-		AlertUserCommand: types.StringValue(fmt.Sprintf("ALTER USER %s SET RSA_PUBLIC_KEY='%s'", acctData[1], keyData)),
+		AccountID: types.StringValue(acctData[0]),
+		Username:  types.StringValue(acctData[1]),
+		AlertUserCommand: types.StringValue(
+			fmt.Sprintf("ALTER USER %s SET RSA_PUBLIC_KEY='%s'", acctData[1], keyData),
+		),
 	}
 	return &value
 }
 
 // convertOAuthClientCredentialV2DTOToModel converts the OAuth Client Credential state object into a model ready for terraform processing.
 // Note: Since Aembit vaults the Client Secret and does not return it in the API, the DTO will never contain the stored value.
-func convertOAuthClientCredentialV2DTOToModel(dto aembit.CredentialProviderV2DTO, state models.CredentialProviderResourceModel) *models.CredentialProviderOAuthClientCredentialsModel {
+func convertOAuthClientCredentialV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	state models.CredentialProviderResourceModel,
+) *models.CredentialProviderOAuthClientCredentialsModel {
 	value := models.CredentialProviderOAuthClientCredentialsModel{ClientSecret: types.StringNull()}
 	value.TokenURL = types.StringValue(dto.TokenURL)
 	value.ClientID = types.StringValue(dto.ClientID)
@@ -1166,7 +1291,10 @@ func convertOAuthClientCredentialV2DTOToModel(dto aembit.CredentialProviderV2DTO
 	}
 
 	// Get the custom parameters to be injected into the model
-	parameters := make([]*models.CredentialProviderOAuthClientCustomParametersModel, len(dto.CustomParameters))
+	parameters := make(
+		[]*models.CredentialProviderOAuthClientCustomParametersModel,
+		len(dto.CustomParameters),
+	)
 	for i, parameter := range dto.CustomParameters {
 		parameters[i] = &models.CredentialProviderOAuthClientCustomParametersModel{
 			Key:       parameter.Key,
@@ -1181,7 +1309,10 @@ func convertOAuthClientCredentialV2DTOToModel(dto aembit.CredentialProviderV2DTO
 
 // convertOAuthAuthorizationCodeV2DTOToModel converts the OAuth Authorization Code state object into a model ready for terraform processing.
 // Note: Since Aembit vaults the Client Secret and does not return it in the API, the DTO will never contain the stored value.
-func convertOAuthAuthorizationCodeV2DTOToModel(dto aembit.CredentialProviderV2DTO, state models.CredentialProviderResourceModel) *models.CredentialProviderOAuthAuthorizationCodeModel {
+func convertOAuthAuthorizationCodeV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	state models.CredentialProviderResourceModel,
+) *models.CredentialProviderOAuthAuthorizationCodeModel {
 	value := models.CredentialProviderOAuthAuthorizationCodeModel{ClientSecret: types.StringNull()}
 	value.OAuthDiscoveryUrl = types.StringValue(dto.OAuthUrl)
 	value.OAuthAuthorizationUrl = types.StringValue(dto.AuthorizationUrl)
@@ -1197,7 +1328,10 @@ func convertOAuthAuthorizationCodeV2DTOToModel(dto aembit.CredentialProviderV2DT
 	}
 
 	// Get the custom parameters to be injected into the model
-	parameters := make([]*models.CredentialProviderOAuthClientCustomParametersModel, len(dto.CustomParameters))
+	parameters := make(
+		[]*models.CredentialProviderOAuthClientCustomParametersModel,
+		len(dto.CustomParameters),
+	)
 	for i, parameter := range dto.CustomParameters {
 		parameters[i] = &models.CredentialProviderOAuthClientCustomParametersModel{
 			Key:       parameter.Key,
@@ -1224,7 +1358,10 @@ func convertOAuthAuthorizationCodeV2DTOToModel(dto aembit.CredentialProviderV2DT
 
 // convertUserPassV2DTOToModel converts the API Key state object into a model ready for terraform processing.
 // Note: Since Aembit vaults the Password and does not return it in the API, the DTO will never contain the stored value.
-func convertUserPassV2DTOToModel(dto aembit.CredentialProviderV2DTO, state models.CredentialProviderResourceModel) *models.CredentialProviderUserPassModel {
+func convertUserPassV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	state models.CredentialProviderResourceModel,
+) *models.CredentialProviderUserPassModel {
 	value := models.CredentialProviderUserPassModel{
 		Username: types.StringValue(dto.Username),
 		Password: types.StringNull(),
@@ -1236,7 +1373,10 @@ func convertUserPassV2DTOToModel(dto aembit.CredentialProviderV2DTO, state model
 }
 
 // convertVaultClientTokenV2DTOToModel converts the VaultClientToken state object into a model ready for terraform processing.
-func convertVaultClientTokenV2DTOToModel(dto aembit.CredentialProviderV2DTO, _ models.CredentialProviderResourceModel) *models.CredentialProviderVaultClientTokenModel {
+func convertVaultClientTokenV2DTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	_ models.CredentialProviderResourceModel,
+) *models.CredentialProviderVaultClientTokenModel {
 	value := models.CredentialProviderVaultClientTokenModel{
 		Subject:                   dto.Subject,
 		SubjectType:               dto.SubjectType,
@@ -1253,8 +1393,8 @@ func convertVaultClientTokenV2DTOToModel(dto aembit.CredentialProviderV2DTO, _ m
 
 	// Get the custom claims to be injected into the model
 	claims := make([]*models.CredentialProviderCustomClaimsModel, len(dto.CustomClaims))
-	//types.ObjectValue(models.CredentialProviderCustomClaimsModel.AttrTypes),
-	//claims := getSetObjectAttr(ctx, model.VaultClientToken, "custom_claims")
+	// types.ObjectValue(models.CredentialProviderCustomClaimsModel.AttrTypes),
+	// claims := getSetObjectAttr(ctx, model.VaultClientToken, "custom_claims")
 	for i, claim := range dto.CustomClaims {
 		claims[i] = &models.CredentialProviderCustomClaimsModel{
 			Key:       claim.Key,
@@ -1267,12 +1407,21 @@ func convertVaultClientTokenV2DTOToModel(dto aembit.CredentialProviderV2DTO, _ m
 }
 
 // convertManagedGitlabAccountDTOToModel converts the GitlabManagedAccount state object into a model ready for terraform processing.
-func convertManagedGitlabAccountDTOToModel(dto aembit.CredentialProviderV2DTO, _ models.CredentialProviderResourceModel) *models.CredentialProviderManagedGitlabAccountModel {
+func convertManagedGitlabAccountDTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	_ models.CredentialProviderResourceModel,
+) *models.CredentialProviderManagedGitlabAccountModel {
 	value := models.CredentialProviderManagedGitlabAccountModel{
-		ServiceAccountUsername:                  types.StringValue(dto.Username),
-		GroupIds:                                convertSliceToSet(strings.Split(dto.GroupIds, ",")),
-		ProjectIds:                              convertSliceToSet(strings.Split(dto.ProjectIds, ",")),
-		LifetimeInDays:                          types.Float32Value(float32(dto.LifetimeInSeconds) / 86400),
+		ServiceAccountUsername: types.StringValue(dto.Username),
+		GroupIds: convertSliceToSet(
+			strings.Split(dto.GroupIds, ","),
+		),
+		ProjectIds: convertSliceToSet(
+			strings.Split(dto.ProjectIds, ","),
+		),
+		LifetimeInDays: types.Float32Value(
+			float32(dto.LifetimeInSeconds) / 86400,
+		),
 		LifetimeInHours:                         types.Int32Value(dto.LifetimeInSeconds / 3600),
 		Scope:                                   dto.Scope,
 		AccessLevel:                             dto.AccessLevel,
@@ -1283,7 +1432,10 @@ func convertManagedGitlabAccountDTOToModel(dto aembit.CredentialProviderV2DTO, _
 }
 
 // convertOidcIdTokenDTOToModel converts the OidcIdToken state object into a model ready for terraform processing.
-func convertOidcIdTokenDTOToModel(dto aembit.CredentialProviderV2DTO, _ models.CredentialProviderResourceModel) *models.CredentialProviderManagedOidcIdToken {
+func convertOidcIdTokenDTOToModel(
+	dto aembit.CredentialProviderV2DTO,
+	_ models.CredentialProviderResourceModel,
+) *models.CredentialProviderManagedOidcIdToken {
 	value := models.CredentialProviderManagedOidcIdToken{
 		Subject:           dto.Subject,
 		SubjectType:       dto.SubjectType,
@@ -1295,8 +1447,8 @@ func convertOidcIdTokenDTOToModel(dto aembit.CredentialProviderV2DTO, _ models.C
 
 	// Get the custom claims to be injected into the model
 	claims := make([]*models.CredentialProviderCustomClaimsModel, len(dto.CustomClaims))
-	//types.ObjectValue(models.CredentialProviderCustomClaimsModel.AttrTypes),
-	//claims := getSetObjectAttr(ctx, model.VaultClientToken, "custom_claims")
+	// types.ObjectValue(models.CredentialProviderCustomClaimsModel.AttrTypes),
+	// claims := getSetObjectAttr(ctx, model.VaultClientToken, "custom_claims")
 	for i, claim := range dto.CustomClaims {
 		claims[i] = &models.CredentialProviderCustomClaimsModel{
 			Key:       claim.Key,
@@ -1309,7 +1461,9 @@ func convertOidcIdTokenDTOToModel(dto aembit.CredentialProviderV2DTO, _ models.C
 }
 
 // Get the custom parameters to be injected into the model.
-func convertCredentialOAuthClientCredentialsCustomParameters(model models.CredentialProviderResourceModel) []aembit.CustomClaimsDTO {
+func convertCredentialOAuthClientCredentialsCustomParameters(
+	model models.CredentialProviderResourceModel,
+) []aembit.CustomClaimsDTO {
 	parameters := make([]aembit.CustomClaimsDTO, len(model.OAuthClientCredentials.CustomParameters))
 	for i, param := range model.OAuthClientCredentials.CustomParameters {
 		parameters[i] = aembit.CustomClaimsDTO{
@@ -1322,7 +1476,9 @@ func convertCredentialOAuthClientCredentialsCustomParameters(model models.Creden
 }
 
 // Get the custom parameters to be injected into the model.
-func convertCredentialOAuthAuthorizationCodeCustomParameters(model models.CredentialProviderResourceModel) []aembit.CustomClaimsDTO {
+func convertCredentialOAuthAuthorizationCodeCustomParameters(
+	model models.CredentialProviderResourceModel,
+) []aembit.CustomClaimsDTO {
 	parameters := make([]aembit.CustomClaimsDTO, len(model.OAuthAuthorizationCode.CustomParameters))
 	for i, param := range model.OAuthAuthorizationCode.CustomParameters {
 		parameters[i] = aembit.CustomClaimsDTO{
@@ -1335,7 +1491,7 @@ func convertCredentialOAuthAuthorizationCodeCustomParameters(model models.Creden
 }
 
 func convertSetToSlice(set []types.String) []string {
-	var result = []string{}
+	result := []string{}
 
 	for _, val := range set {
 		result = append(result, val.ValueString())
@@ -1345,7 +1501,7 @@ func convertSetToSlice(set []types.String) []string {
 }
 
 func convertSliceToSet(slice []string) []types.String {
-	var result = []types.String{}
+	result := []types.String{}
 
 	for _, val := range slice {
 		result = append(result, types.StringValue(val))

--- a/internal/provider/credential_provider_resource_test.go
+++ b/internal/provider/credential_provider_resource_test.go
@@ -30,9 +30,17 @@ func testDeleteCredentialProvider(resourceName string) resource.TestCheckFunc {
 }
 
 func TestAccCredentialProviderResource_AembitToken(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/aembit/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/aembit/TestAccCredentialProviderResource.tfmod")
-	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(string(createFile), string(modifyFile), "TF Acceptance Role for Token")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/aembit/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/aembit/TestAccCredentialProviderResource.tfmod",
+	)
+	createFileConfig, modifyFileConfig, _ := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"TF Acceptance Role for Token",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -42,29 +50,55 @@ func TestAccCredentialProviderResource_AembitToken(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider set values
-					resource.TestCheckResourceAttr(testCredentialProviderAembit, "name", "TF Acceptance Aembit Token"),
-					resource.TestCheckResourceAttr(testCredentialProviderAembit, "aembit_access_token.lifetime", "1800"),
+					resource.TestCheckResourceAttr(
+						testCredentialProviderAembit,
+						"name",
+						"TF Acceptance Aembit Token",
+					),
+					resource.TestCheckResourceAttr(
+						testCredentialProviderAembit,
+						"aembit_access_token.lifetime",
+						"1800",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testCredentialProviderAembit, "id"),
-					resource.TestCheckResourceAttrSet(testCredentialProviderAembit, "aembit_access_token.audience"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProviderAembit,
+						"aembit_access_token.audience",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(testCredentialProviderAembit, "id"),
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: createFileConfig, Check: testDeleteCredentialProvider(testCredentialProviderAembit), ExpectNonEmptyPlan: true},
+			{
+				Config:             createFileConfig,
+				Check:              testDeleteCredentialProvider(testCredentialProviderAembit),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: createFileConfig},
 			// ImportState testing
-			{ResourceName: testCredentialProviderAembit, ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      testCredentialProviderAembit,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testCredentialProviderAembit, "name", "TF Acceptance Aembit Token - Modified"),
+					resource.TestCheckResourceAttr(
+						testCredentialProviderAembit,
+						"name",
+						"TF Acceptance Aembit Token - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testCredentialProviderAembit, "aembit_access_token.audience"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProviderAembit,
+						"aembit_access_token.audience",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -73,8 +107,12 @@ func TestAccCredentialProviderResource_AembitToken(t *testing.T) {
 }
 
 func TestAccCredentialProviderResource_ApiKey(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/apikey/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/apikey/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/apikey/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/apikey/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -84,7 +122,11 @@ func TestAccCredentialProviderResource_ApiKey(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr("aembit_credential_provider.api_key", "name", "TF Acceptance API Key"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.api_key",
+						"name",
+						"TF Acceptance API Key",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.api_key", "id"),
 					// Verify placeholder ID is set
@@ -92,13 +134,21 @@ func TestAccCredentialProviderResource_ApiKey(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_credential_provider.api_key", ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      "aembit_credential_provider.api_key",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_credential_provider.api_key", "name", "TF Acceptance API Key - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.api_key",
+						"name",
+						"TF Acceptance API Key - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -108,7 +158,9 @@ func TestAccCredentialProviderResource_ApiKey(t *testing.T) {
 
 func TestAccCredentialProviderResource_AwsSTS(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/credential/aws/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/aws/TestAccCredentialProviderResource.tfmod")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/aws/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -118,28 +170,56 @@ func TestAccCredentialProviderResource_AwsSTS(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential set values
-					resource.TestCheckResourceAttr("aembit_credential_provider.aws", "name", "TF Acceptance AWS STS"),
-					resource.TestCheckResourceAttr("aembit_credential_provider.aws", "aws_sts.lifetime", "1800"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.aws",
+						"name",
+						"TF Acceptance AWS STS",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.aws",
+						"aws_sts.lifetime",
+						"1800",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "id"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "aws_sts.oidc_issuer"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "aws_sts.token_audience"),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.aws",
+						"aws_sts.oidc_issuer",
+					),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.aws",
+						"aws_sts.token_audience",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "id"),
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_credential_provider.aws", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "aembit_credential_provider.aws",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_credential_provider.aws", "name", "TF Acceptance AWS STS - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.aws",
+						"name",
+						"TF Acceptance AWS STS - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "id"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "aws_sts.oidc_issuer"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "aws_sts.token_audience"),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.aws",
+						"aws_sts.oidc_issuer",
+					),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.aws",
+						"aws_sts.token_audience",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -149,7 +229,9 @@ func TestAccCredentialProviderResource_AwsSTS(t *testing.T) {
 
 func TestAccCredentialProviderResource_GoogleWorkload(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/credential/gcp/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/gcp/TestAccCredentialProviderResource.tfmod")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/gcp/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -159,26 +241,48 @@ func TestAccCredentialProviderResource_GoogleWorkload(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider set values
-					resource.TestCheckResourceAttr("aembit_credential_provider.gcp", "name", "TF Acceptance GCP Workload"),
-					resource.TestCheckResourceAttr("aembit_credential_provider.gcp", "google_workload_identity.lifetime", "1800"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.gcp",
+						"name",
+						"TF Acceptance GCP Workload",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.gcp",
+						"google_workload_identity.lifetime",
+						"1800",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "id"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "google_workload_identity.oidc_issuer"),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.gcp",
+						"google_workload_identity.oidc_issuer",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "id"),
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_credential_provider.gcp", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "aembit_credential_provider.gcp",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_credential_provider.gcp", "name", "TF Acceptance GCP Workload - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.gcp",
+						"name",
+						"TF Acceptance GCP Workload - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "id"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "google_workload_identity.oidc_issuer"),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.gcp",
+						"google_workload_identity.oidc_issuer",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -188,8 +292,12 @@ func TestAccCredentialProviderResource_GoogleWorkload(t *testing.T) {
 
 func TestAccCredentialProviderResource_AzureEntraToken(t *testing.T) {
 	const credentialProviderName string = "aembit_credential_provider.ae"
-	createFile, _ := os.ReadFile("../../tests/credential/azure-entra/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/azure-entra/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/azure-entra/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/azure-entra/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -199,14 +307,41 @@ func TestAccCredentialProviderResource_AzureEntraToken(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider set values
-					resource.TestCheckResourceAttr(credentialProviderName, "name", "TF Acceptance Azure Entra Workload"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.audience", "audience"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.subject", "subject"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.scope", "scope"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.azure_tenant", "00000000-0000-0000-0000-000000000000"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.client_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"name",
+						"TF Acceptance Azure Entra Workload",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.audience",
+						"audience",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.subject",
+						"subject",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.scope",
+						"scope",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.azure_tenant",
+						"00000000-0000-0000-0000-000000000000",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.client_id",
+						"00000000-0000-0000-0000-000000000000",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(credentialProviderName, "azure_entra_workload_identity.oidc_issuer"),
+					resource.TestCheckResourceAttrSet(
+						credentialProviderName,
+						"azure_entra_workload_identity.oidc_issuer",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(credentialProviderName, "id"),
 				),
@@ -218,14 +353,41 @@ func TestAccCredentialProviderResource_AzureEntraToken(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(credentialProviderName, "name", "TF Acceptance Azure Entra Workload - Modified"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.audience", "new audience"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.subject", "new subject"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.scope", "new scope"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.azure_tenant", "11111111-1111-1111-1111-111111111111"),
-					resource.TestCheckResourceAttr(credentialProviderName, "azure_entra_workload_identity.client_id", "11111111-1111-1111-1111-111111111111"),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"name",
+						"TF Acceptance Azure Entra Workload - Modified",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.audience",
+						"new audience",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.subject",
+						"new subject",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.scope",
+						"new scope",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.azure_tenant",
+						"11111111-1111-1111-1111-111111111111",
+					),
+					resource.TestCheckResourceAttr(
+						credentialProviderName,
+						"azure_entra_workload_identity.client_id",
+						"11111111-1111-1111-1111-111111111111",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(credentialProviderName, "azure_entra_workload_identity.oidc_issuer"),
+					resource.TestCheckResourceAttrSet(
+						credentialProviderName,
+						"azure_entra_workload_identity.oidc_issuer",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(credentialProviderName, "id"),
 				),
@@ -236,8 +398,12 @@ func TestAccCredentialProviderResource_AzureEntraToken(t *testing.T) {
 }
 
 func TestAccCredentialProviderResource_SnowflakeToken(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/snowflake/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/snowflake/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/snowflake/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/snowflake/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -247,25 +413,43 @@ func TestAccCredentialProviderResource_SnowflakeToken(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr("aembit_credential_provider.snowflake", "name", "TF Acceptance Snowflake Token"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.snowflake",
+						"name",
+						"TF Acceptance Snowflake Token",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "id"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "snowflake_jwt.alter_user_command"),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.snowflake",
+						"snowflake_jwt.alter_user_command",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "id"),
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_credential_provider.snowflake", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "aembit_credential_provider.snowflake",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_credential_provider.snowflake", "name", "TF Acceptance Snowflake Token - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.snowflake",
+						"name",
+						"TF Acceptance Snowflake Token - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "id"),
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "snowflake_jwt.alter_user_command"),
+					resource.TestCheckResourceAttrSet(
+						"aembit_credential_provider.snowflake",
+						"snowflake_jwt.alter_user_command",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -273,12 +457,18 @@ func TestAccCredentialProviderResource_SnowflakeToken(t *testing.T) {
 	})
 }
 
-const testOAuthClientCredentialsAuthHeader string = "aembit_credential_provider.oauth_authHeader"
-const testOAuthClientCredentialsPostBody string = "aembit_credential_provider.oauth_postBody"
+const (
+	testOAuthClientCredentialsAuthHeader string = "aembit_credential_provider.oauth_authHeader"
+	testOAuthClientCredentialsPostBody   string = "aembit_credential_provider.oauth_postBody"
+)
 
 func TestAccCredentialProviderResource_OAuthClientCredentialsAuthHeader(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -288,7 +478,11 @@ func TestAccCredentialProviderResource_OAuthClientCredentialsAuthHeader(t *testi
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr(testOAuthClientCredentialsAuthHeader, "name", "TF Acceptance OAuth"),
+					resource.TestCheckResourceAttr(
+						testOAuthClientCredentialsAuthHeader,
+						"name",
+						"TF Acceptance OAuth",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testOAuthClientCredentialsAuthHeader, "id"),
 					// Verify placeholder ID is set
@@ -296,13 +490,21 @@ func TestAccCredentialProviderResource_OAuthClientCredentialsAuthHeader(t *testi
 				),
 			},
 			// ImportState testing
-			{ResourceName: testOAuthClientCredentialsAuthHeader, ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      testOAuthClientCredentialsAuthHeader,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testOAuthClientCredentialsAuthHeader, "name", "TF Acceptance OAuth - Modified"),
+					resource.TestCheckResourceAttr(
+						testOAuthClientCredentialsAuthHeader,
+						"name",
+						"TF Acceptance OAuth - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -311,8 +513,12 @@ func TestAccCredentialProviderResource_OAuthClientCredentialsAuthHeader(t *testi
 }
 
 func TestAccCredentialProviderResource_OAuthClientCredentialsPostBody(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/oauth-client-credentials/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -322,7 +528,11 @@ func TestAccCredentialProviderResource_OAuthClientCredentialsPostBody(t *testing
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr(testOAuthClientCredentialsPostBody, "name", "TF Acceptance OAuth"),
+					resource.TestCheckResourceAttr(
+						testOAuthClientCredentialsPostBody,
+						"name",
+						"TF Acceptance OAuth",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testOAuthClientCredentialsPostBody, "id"),
 					// Verify placeholder ID is set
@@ -330,13 +540,21 @@ func TestAccCredentialProviderResource_OAuthClientCredentialsPostBody(t *testing
 				),
 			},
 			// ImportState testing
-			{ResourceName: testOAuthClientCredentialsPostBody, ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      testOAuthClientCredentialsPostBody,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testOAuthClientCredentialsPostBody, "name", "TF Acceptance OAuth - Modified"),
+					resource.TestCheckResourceAttr(
+						testOAuthClientCredentialsPostBody,
+						"name",
+						"TF Acceptance OAuth - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -344,13 +562,19 @@ func TestAccCredentialProviderResource_OAuthClientCredentialsPostBody(t *testing
 	})
 }
 
-const testOAuthAuthCodeResource string = "aembit_credential_provider.oauth_authorization_code"
-const testOAuthAuthCodeEmptyCustomParameters string = "aembit_credential_provider.oauth_authorization_code_empty_custom_parameters"
-const testOAuthAuthCodeUserAuthUrl = "oauth_authorization_code.user_authorization_url"
+const (
+	testOAuthAuthCodeResource              string = "aembit_credential_provider.oauth_authorization_code"
+	testOAuthAuthCodeEmptyCustomParameters string = "aembit_credential_provider.oauth_authorization_code_empty_custom_parameters"
+	testOAuthAuthCodeUserAuthUrl                  = "oauth_authorization_code.user_authorization_url"
+)
 
 func TestAccCredentialProviderResource_OAuthAuthorizationCode(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/oauth-authorization-code/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/oauth-authorization-code/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/oauth-authorization-code/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/oauth-authorization-code/TestAccCredentialProviderResource.tfmod",
+	)
 
 	firstID := uuid.New().String()
 	secondID := uuid.New().String()
@@ -360,24 +584,42 @@ func TestAccCredentialProviderResource_OAuthAuthorizationCode(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: strings.ReplaceAll(strings.ReplaceAll(string(createFile), "replace-with-uuid-first", firstID), "replace-with-uuid-second", secondID),
+				Config: strings.ReplaceAll(
+					strings.ReplaceAll(string(createFile), "replace-with-uuid-first", firstID),
+					"replace-with-uuid-second",
+					secondID,
+				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr(testOAuthAuthCodeResource, "name", "TF Acceptance OAuth Authorization Code"),
-					//Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttr(
+						testOAuthAuthCodeResource,
+						"name",
+						"TF Acceptance OAuth Authorization Code",
+					),
+					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testOAuthAuthCodeResource, "id"),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(testOAuthAuthCodeResource, "id"),
 					// Verify we get back a user_authorization_url
-					resource.TestCheckResourceAttrSet(testOAuthAuthCodeResource, testOAuthAuthCodeUserAuthUrl),
+					resource.TestCheckResourceAttrSet(
+						testOAuthAuthCodeResource,
+						testOAuthAuthCodeUserAuthUrl,
+					),
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr(testOAuthAuthCodeEmptyCustomParameters, "name", "TF Acceptance OAuth Authorization Code"),
-					//Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttr(
+						testOAuthAuthCodeEmptyCustomParameters,
+						"name",
+						"TF Acceptance OAuth Authorization Code",
+					),
+					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testOAuthAuthCodeEmptyCustomParameters, "id"),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(testOAuthAuthCodeEmptyCustomParameters, "id"),
 					// Verify we get back a user_authorization_url
-					resource.TestCheckResourceAttrSet(testOAuthAuthCodeEmptyCustomParameters, testOAuthAuthCodeUserAuthUrl),
+					resource.TestCheckResourceAttrSet(
+						testOAuthAuthCodeEmptyCustomParameters,
+						testOAuthAuthCodeUserAuthUrl,
+					),
 				),
 			},
 			// ImportState testing
@@ -387,9 +629,16 @@ func TestAccCredentialProviderResource_OAuthAuthorizationCode(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testOAuthAuthCodeResource, "name", "TF Acceptance OAuth Authorization Code - Modified"),
+					resource.TestCheckResourceAttr(
+						testOAuthAuthCodeResource,
+						"name",
+						"TF Acceptance OAuth Authorization Code - Modified",
+					),
 					// Verify we get back a user_authorization_url
-					resource.TestCheckResourceAttrSet(testOAuthAuthCodeResource, testOAuthAuthCodeUserAuthUrl),
+					resource.TestCheckResourceAttrSet(
+						testOAuthAuthCodeResource,
+						testOAuthAuthCodeUserAuthUrl,
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -398,8 +647,12 @@ func TestAccCredentialProviderResource_OAuthAuthorizationCode(t *testing.T) {
 }
 
 func TestAccCredentialProviderResource_UsernamePassword(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/userpass/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/userpass/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/userpass/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/userpass/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -409,7 +662,11 @@ func TestAccCredentialProviderResource_UsernamePassword(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr("aembit_credential_provider.userpass", "name", "TF Acceptance Username Password"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.userpass",
+						"name",
+						"TF Acceptance Username Password",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.userpass", "id"),
 					// Verify placeholder ID is set
@@ -417,13 +674,21 @@ func TestAccCredentialProviderResource_UsernamePassword(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_credential_provider.userpass", ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      "aembit_credential_provider.userpass",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_credential_provider.userpass", "name", "TF Acceptance Username Password - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.userpass",
+						"name",
+						"TF Acceptance Username Password - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -432,8 +697,12 @@ func TestAccCredentialProviderResource_UsernamePassword(t *testing.T) {
 }
 
 func TestAccCredentialProviderResource_VaultClientToken(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/vault/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/vault/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/vault/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/vault/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -443,32 +712,76 @@ func TestAccCredentialProviderResource_VaultClientToken(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", "name", "TF Acceptance Vault"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						"name",
+						"TF Acceptance Vault",
+					),
 					// Verify Tags.
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", tagsCount, "2"),
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", tagsColor, "blue"),
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", tagsDay, "Sunday"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						tagsColor,
+						"blue",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						tagsDay,
+						"Sunday",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.vault", "id"),
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", "vault_client_token.vault_forwarding", ""),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						"vault_client_token.vault_forwarding",
+						"",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet("aembit_credential_provider.vault", "id"),
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_credential_provider.vault", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "aembit_credential_provider.vault",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", "name", "TF Acceptance Vault - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						"name",
+						"TF Acceptance Vault - Modified",
+					),
 					// Verify Tags.
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", tagsCount, "2"),
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", tagsColor, "orange"),
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", tagsDay, "Tuesday"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						tagsColor,
+						"orange",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						tagsDay,
+						"Tuesday",
+					),
 					// Verify Vault_Forwarding update
-					resource.TestCheckResourceAttr("aembit_credential_provider.vault", "vault_client_token.vault_forwarding", "conditional"),
+					resource.TestCheckResourceAttr(
+						"aembit_credential_provider.vault",
+						"vault_client_token.vault_forwarding",
+						"conditional",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -481,8 +794,12 @@ var gitlabManagedAccountResourcePath = "aembit_credential_provider.gitlab_manage
 func TestAccCredentialProviderResource_ManagedGitlabAccount(t *testing.T) {
 	t.Skip("skipping test until we figure out a way to handle the GitLab tokens appropriately")
 
-	createFile, _ := os.ReadFile("../../tests/credential/gitlab-managed-account/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/gitlab-managed-account/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/gitlab-managed-account/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/gitlab-managed-account/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -492,8 +809,16 @@ func TestAccCredentialProviderResource_ManagedGitlabAccount(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr(gitlabManagedAccountResourcePath, "name", "TF Acceptance Managed Gitlab Account"),
-					resource.TestCheckResourceAttr(gitlabManagedAccountResourcePath, "managed_gitlab_account.service_account_username", "test_service_account"),
+					resource.TestCheckResourceAttr(
+						gitlabManagedAccountResourcePath,
+						"name",
+						"TF Acceptance Managed Gitlab Account",
+					),
+					resource.TestCheckResourceAttr(
+						gitlabManagedAccountResourcePath,
+						"managed_gitlab_account.service_account_username",
+						"test_service_account",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(gitlabManagedAccountResourcePath, "id"),
 					// Verify placeholder ID is set
@@ -501,13 +826,21 @@ func TestAccCredentialProviderResource_ManagedGitlabAccount(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: gitlabManagedAccountResourcePath, ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      gitlabManagedAccountResourcePath,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(gitlabManagedAccountResourcePath, "name", "TF Acceptance Managed Gitlab Account - Updated"),
+					resource.TestCheckResourceAttr(
+						gitlabManagedAccountResourcePath,
+						"name",
+						"TF Acceptance Managed Gitlab Account - Updated",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -518,8 +851,12 @@ func TestAccCredentialProviderResource_ManagedGitlabAccount(t *testing.T) {
 var oidcIdTokenResourcePath = "aembit_credential_provider.oidc_id_token"
 
 func TestAccCredentialProviderResource_OidcIdToken(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/oidc-id-token/TestAccCredentialProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/credential/oidc-id-token/TestAccCredentialProviderResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/oidc-id-token/TestAccCredentialProviderResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/credential/oidc-id-token/TestAccCredentialProviderResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -529,7 +866,11 @@ func TestAccCredentialProviderResource_OidcIdToken(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
-					resource.TestCheckResourceAttr(oidcIdTokenResourcePath, "name", "TF Acceptance OIDC ID Token"),
+					resource.TestCheckResourceAttr(
+						oidcIdTokenResourcePath,
+						"name",
+						"TF Acceptance OIDC ID Token",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(oidcIdTokenResourcePath, "id"),
 					// Verify placeholder ID is set
@@ -543,7 +884,11 @@ func TestAccCredentialProviderResource_OidcIdToken(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(oidcIdTokenResourcePath, "name", "TF Acceptance OIDC ID Token - Modified"),
+					resource.TestCheckResourceAttr(
+						oidcIdTokenResourcePath,
+						"name",
+						"TF Acceptance OIDC ID Token - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/credential_provider_resource_test.go
+++ b/internal/provider/credential_provider_resource_test.go
@@ -12,7 +12,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testCredentialProviderAembit string = "aembit_credential_provider.aembit"
+const (
+	testCredentialProviderAembit    string = "aembit_credential_provider.aembit"
+	testCredentialProviderApiKey    string = "aembit_credential_provider.api_key"
+	testCredentialProviderAWS       string = "aembit_credential_provider.aws"
+	testCredentialProviderGCP       string = "aembit_credential_provider.gcp"
+	testCredentialProviderSnowflake string = "aembit_credential_provider.snowflake"
+	testCredentialProviderUserPass  string = "aembit_credential_provider.userpass"
+	testCredentialProviderVault     string = "aembit_credential_provider.vault"
+)
 
 func testDeleteCredentialProvider(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -123,19 +131,19 @@ func TestAccCredentialProviderResource_ApiKey(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.api_key",
+						testCredentialProviderApiKey,
 						"name",
 						"TF Acceptance API Key",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.api_key", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderApiKey, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.api_key", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderApiKey, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_credential_provider.api_key",
+				ResourceName:      testCredentialProviderApiKey,
 				ImportState:       true,
 				ImportStateVerify: false,
 			},
@@ -145,7 +153,7 @@ func TestAccCredentialProviderResource_ApiKey(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.api_key",
+						testCredentialProviderApiKey,
 						"name",
 						"TF Acceptance API Key - Modified",
 					),
@@ -171,32 +179,32 @@ func TestAccCredentialProviderResource_AwsSTS(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential set values
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.aws",
+						testCredentialProviderGCP,
 						"name",
 						"TF Acceptance AWS STS",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.aws",
+						testCredentialProviderGCP,
 						"aws_sts.lifetime",
 						"1800",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.aws",
+						testCredentialProviderGCP,
 						"aws_sts.oidc_issuer",
 					),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.aws",
+						testCredentialProviderGCP,
 						"aws_sts.token_audience",
 					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_credential_provider.aws",
+				ResourceName:      testCredentialProviderGCP,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -206,18 +214,18 @@ func TestAccCredentialProviderResource_AwsSTS(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.aws",
+						testCredentialProviderGCP,
 						"name",
 						"TF Acceptance AWS STS - Modified",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.aws", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.aws",
+						testCredentialProviderGCP,
 						"aws_sts.oidc_issuer",
 					),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.aws",
+						testCredentialProviderGCP,
 						"aws_sts.token_audience",
 					),
 				),
@@ -242,28 +250,28 @@ func TestAccCredentialProviderResource_GoogleWorkload(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider set values
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.gcp",
+						testCredentialProviderGCP,
 						"name",
 						"TF Acceptance GCP Workload",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.gcp",
+						testCredentialProviderGCP,
 						"google_workload_identity.lifetime",
 						"1800",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.gcp",
+						testCredentialProviderGCP,
 						"google_workload_identity.oidc_issuer",
 					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_credential_provider.gcp",
+				ResourceName:      testCredentialProviderGCP,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -273,14 +281,14 @@ func TestAccCredentialProviderResource_GoogleWorkload(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.gcp",
+						testCredentialProviderGCP,
 						"name",
 						"TF Acceptance GCP Workload - Modified",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.gcp", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.gcp",
+						testCredentialProviderGCP,
 						"google_workload_identity.oidc_issuer",
 					),
 				),
@@ -414,23 +422,23 @@ func TestAccCredentialProviderResource_SnowflakeToken(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.snowflake",
+						testCredentialProviderSnowflake,
 						"name",
 						"TF Acceptance Snowflake Token",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderSnowflake, "id"),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.snowflake",
+						testCredentialProviderSnowflake,
 						"snowflake_jwt.alter_user_command",
 					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderSnowflake, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_credential_provider.snowflake",
+				ResourceName:      testCredentialProviderSnowflake,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -440,14 +448,14 @@ func TestAccCredentialProviderResource_SnowflakeToken(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.snowflake",
+						testCredentialProviderSnowflake,
 						"name",
 						"TF Acceptance Snowflake Token - Modified",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.snowflake", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderSnowflake, "id"),
 					resource.TestCheckResourceAttrSet(
-						"aembit_credential_provider.snowflake",
+						testCredentialProviderSnowflake,
 						"snowflake_jwt.alter_user_command",
 					),
 				),
@@ -663,19 +671,19 @@ func TestAccCredentialProviderResource_UsernamePassword(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.userpass",
+						testCredentialProviderUserPass,
 						"name",
 						"TF Acceptance Username Password",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.userpass", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderUserPass, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.userpass", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderUserPass, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_credential_provider.userpass",
+				ResourceName:      testCredentialProviderUserPass,
 				ImportState:       true,
 				ImportStateVerify: false,
 			},
@@ -685,7 +693,7 @@ func TestAccCredentialProviderResource_UsernamePassword(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.userpass",
+						testCredentialProviderUserPass,
 						"name",
 						"TF Acceptance Username Password - Modified",
 					),
@@ -713,40 +721,40 @@ func TestAccCredentialProviderResource_VaultClientToken(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						"name",
 						"TF Acceptance Vault",
 					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						tagsCount,
 						"2",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						tagsColor,
 						"blue",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						tagsDay,
 						"Sunday",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.vault", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderVault, "id"),
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						"vault_client_token.vault_forwarding",
 						"",
 					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_credential_provider.vault", "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderVault, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_credential_provider.vault",
+				ResourceName:      testCredentialProviderVault,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -756,29 +764,29 @@ func TestAccCredentialProviderResource_VaultClientToken(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						"name",
 						"TF Acceptance Vault - Modified",
 					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						tagsCount,
 						"2",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						tagsColor,
 						"orange",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						tagsDay,
 						"Tuesday",
 					),
 					// Verify Vault_Forwarding update
 					resource.TestCheckResourceAttr(
-						"aembit_credential_provider.vault",
+						testCredentialProviderVault,
 						"vault_client_token.vault_forwarding",
 						"conditional",
 					),

--- a/internal/provider/credential_provider_resource_test.go
+++ b/internal/provider/credential_provider_resource_test.go
@@ -179,32 +179,32 @@ func TestAccCredentialProviderResource_AwsSTS(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Credential set values
 					resource.TestCheckResourceAttr(
-						testCredentialProviderGCP,
+						testCredentialProviderAWS,
 						"name",
 						"TF Acceptance AWS STS",
 					),
 					resource.TestCheckResourceAttr(
-						testCredentialProviderGCP,
+						testCredentialProviderAWS,
 						"aws_sts.lifetime",
 						"1800",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderAWS, "id"),
 					resource.TestCheckResourceAttrSet(
-						testCredentialProviderGCP,
+						testCredentialProviderAWS,
 						"aws_sts.oidc_issuer",
 					),
 					resource.TestCheckResourceAttrSet(
-						testCredentialProviderGCP,
+						testCredentialProviderAWS,
 						"aws_sts.token_audience",
 					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderAWS, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      testCredentialProviderGCP,
+				ResourceName:      testCredentialProviderAWS,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -214,18 +214,18 @@ func TestAccCredentialProviderResource_AwsSTS(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						testCredentialProviderGCP,
+						testCredentialProviderAWS,
 						"name",
 						"TF Acceptance AWS STS - Modified",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testCredentialProviderGCP, "id"),
+					resource.TestCheckResourceAttrSet(testCredentialProviderAWS, "id"),
 					resource.TestCheckResourceAttrSet(
-						testCredentialProviderGCP,
+						testCredentialProviderAWS,
 						"aws_sts.oidc_issuer",
 					),
 					resource.TestCheckResourceAttrSet(
-						testCredentialProviderGCP,
+						testCredentialProviderAWS,
 						"aws_sts.token_audience",
 					),
 				),

--- a/internal/provider/credential_provider_resource_test.go
+++ b/internal/provider/credential_provider_resource_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 const (
-	testCredentialProviderAembit    string = "aembit_credential_provider.aembit"
-	testCredentialProviderApiKey    string = "aembit_credential_provider.api_key"
-	testCredentialProviderAWS       string = "aembit_credential_provider.aws"
-	testCredentialProviderGCP       string = "aembit_credential_provider.gcp"
-	testCredentialProviderSnowflake string = "aembit_credential_provider.snowflake"
-	testCredentialProviderUserPass  string = "aembit_credential_provider.userpass"
-	testCredentialProviderVault     string = "aembit_credential_provider.vault"
+	testCredentialProviderAembit    = "aembit_credential_provider.aembit"
+	testCredentialProviderApiKey    = "aembit_credential_provider.api_key"
+	testCredentialProviderAWS       = "aembit_credential_provider.aws"
+	testCredentialProviderGCP       = "aembit_credential_provider.gcp"
+	testCredentialProviderSnowflake = "aembit_credential_provider.snowflake"
+	testCredentialProviderUserPass  = "aembit_credential_provider.userpass"
+	testCredentialProviderVault     = "aembit_credential_provider.vault"
 )
 
 func testDeleteCredentialProvider(resourceName string) resource.TestCheckFunc {

--- a/internal/provider/credential_providers_data_source.go
+++ b/internal/provider/credential_providers_data_source.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -29,17 +29,29 @@ type credentialProvidersDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *credentialProvidersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *credentialProvidersDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *credentialProvidersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *credentialProvidersDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_credential_providers"
 }
 
 // Schema defines the schema for the resource.
-func (d *credentialProvidersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *credentialProvidersDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages an credential provider.",
 		Attributes: map[string]schema.Attribute{
@@ -461,7 +473,11 @@ func (d *credentialProvidersDataSource) Schema(_ context.Context, _ datasource.S
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *credentialProvidersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *credentialProvidersDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.CredentialProvidersDataSourceModel
 
 	credentialProviders, err := d.client.GetCredentialProvidersV2(nil)
@@ -475,7 +491,13 @@ func (d *credentialProvidersDataSource) Read(ctx context.Context, req datasource
 
 	// Map response body to model
 	for _, credentialProvider := range credentialProviders {
-		credentialProviderState := convertCredentialProviderV2DTOToModel(ctx, credentialProvider, models.CredentialProviderResourceModel{}, d.client.Tenant, d.client.StackDomain)
+		credentialProviderState := convertCredentialProviderV2DTOToModel(
+			ctx,
+			credentialProvider,
+			models.CredentialProviderResourceModel{},
+			d.client.Tenant,
+			d.client.StackDomain,
+		)
 		state.CredentialProviders = append(state.CredentialProviders, credentialProviderState)
 	}
 

--- a/internal/provider/credential_providers_data_source_test.go
+++ b/internal/provider/credential_providers_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testCredentialProvidersDataSource string = "data.aembit_credential_providers.test"
-const testCredentialProviderResource string = "aembit_credential_provider.oauth"
+const (
+	testCredentialProvidersDataSource string = "data.aembit_credential_providers.test"
+	testCredentialProviderResource    string = "aembit_credential_provider.oauth"
+)
 
 func testFindCredentialProvider(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -29,7 +31,9 @@ func testFindCredentialProvider(resourceName string) resource.TestCheckFunc {
 }
 
 func TestAccCredentialProvidersDataSource(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/credential/data/TestAccCredentialProvidersDataSource.tf")
+	createFile, _ := os.ReadFile(
+		"../../tests/credential/data/TestAccCredentialProvidersDataSource.tf",
+	)
 	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "TF Acceptance OAuth")
 
 	resource.Test(t, resource.TestCase{
@@ -40,9 +44,15 @@ func TestAccCredentialProvidersDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Credential Providers returned
-					resource.TestCheckResourceAttrSet(testCredentialProvidersDataSource, "credential_providers.#"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProvidersDataSource,
+						"credential_providers.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testCredentialProvidersDataSource, "credential_providers.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testCredentialProvidersDataSource,
+						"credential_providers.0.id",
+					),
 					// Find newly created entry
 					testFindCredentialProvider(testCredentialProviderResource),
 				),

--- a/internal/provider/discovery_integration_resource.go
+++ b/internal/provider/discovery_integration_resource.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -16,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -36,17 +36,29 @@ type discoveryIntegrationResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *discoveryIntegrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *discoveryIntegrationResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_discovery_integration"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *discoveryIntegrationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *discoveryIntegrationResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *discoveryIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *discoveryIntegrationResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -137,7 +149,11 @@ func (r *discoveryIntegrationResource) Schema(_ context.Context, _ resource.Sche
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *discoveryIntegrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *discoveryIntegrationResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.DiscoveryIntegrationResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -147,10 +163,13 @@ func (r *discoveryIntegrationResource) Create(ctx context.Context, req resource.
 	}
 
 	// Generate API request body from plan
-	var discoveryIntegration aembit.DiscoveryIntegrationDTO = convertDiscoveryIntegrationModelToDTO(ctx, plan, nil)
+	discoveryIntegration := convertDiscoveryIntegrationModelToDTO(ctx, plan, nil)
 
 	// Create new Discovery Integration
-	discoveryIntegrationResponse, err := r.client.CreateDiscoveryIntegration(discoveryIntegration, nil)
+	discoveryIntegrationResponse, err := r.client.CreateDiscoveryIntegration(
+		discoveryIntegration,
+		nil,
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Discovery Integration",
@@ -171,7 +190,11 @@ func (r *discoveryIntegrationResource) Create(ctx context.Context, req resource.
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *discoveryIntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *discoveryIntegrationResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.DiscoveryIntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -181,11 +204,18 @@ func (r *discoveryIntegrationResource) Read(ctx context.Context, req resource.Re
 	}
 
 	// Get refreshed workload value from Aembit
-	discoveryIntegration, err, notFound := r.client.GetDiscoveryIntegration(state.ID.ValueString(), nil)
+	discoveryIntegration, err, notFound := r.client.GetDiscoveryIntegration(
+		state.ID.ValueString(),
+		nil,
+	)
 	if err != nil {
 		resp.Diagnostics.AddWarning(
 			"Error reading Discovery Integration",
-			fmt.Sprintf("An error occurred while attempting to fetch the Discovery Integration with ID '%s' from Terraform state: %v", state.ID.ValueString(), err.Error()),
+			fmt.Sprintf(
+				"An error occurred while attempting to fetch the Discovery Integration with ID '%s' from Terraform state: %v",
+				state.ID.ValueString(),
+				err.Error(),
+			),
 		)
 
 		// If the resource is not found on Aembit Cloud, delete it locally
@@ -207,7 +237,11 @@ func (r *discoveryIntegrationResource) Read(ctx context.Context, req resource.Re
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *discoveryIntegrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *discoveryIntegrationResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.DiscoveryIntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -217,7 +251,7 @@ func (r *discoveryIntegrationResource) Update(ctx context.Context, req resource.
 	}
 
 	// Extract external ID from state
-	var externalID string = state.ID.ValueString()
+	externalID := state.ID.ValueString()
 
 	// Retrieve values from plan
 	var plan models.DiscoveryIntegrationResourceModel
@@ -228,7 +262,7 @@ func (r *discoveryIntegrationResource) Update(ctx context.Context, req resource.
 	}
 
 	// Generate API request body from plan
-	var discoveryIntegration aembit.DiscoveryIntegrationDTO = convertDiscoveryIntegrationModelToDTO(ctx, plan, &externalID)
+	discoveryIntegration := convertDiscoveryIntegrationModelToDTO(ctx, plan, &externalID)
 
 	// Update Discovery Integration
 	serverWorkload, err := r.client.UpdateDiscoveryIntegration(discoveryIntegration, nil)
@@ -252,7 +286,11 @@ func (r *discoveryIntegrationResource) Update(ctx context.Context, req resource.
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *discoveryIntegrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *discoveryIntegrationResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.DiscoveryIntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -285,12 +323,20 @@ func (r *discoveryIntegrationResource) Delete(ctx context.Context, req resource.
 }
 
 // Imports an existing resource by passing externalID.
-func (r *discoveryIntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *discoveryIntegrationResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalID and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertDiscoveryIntegrationModelToDTO(ctx context.Context, model models.DiscoveryIntegrationResourceModel, externalID *string) aembit.DiscoveryIntegrationDTO {
+func convertDiscoveryIntegrationModelToDTO(
+	ctx context.Context,
+	model models.DiscoveryIntegrationResourceModel,
+	externalID *string,
+) aembit.DiscoveryIntegrationDTO {
 	var discoveryIntegration aembit.DiscoveryIntegrationDTO
 	discoveryIntegration.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -302,7 +348,7 @@ func convertDiscoveryIntegrationModelToDTO(ctx context.Context, model models.Dis
 	discoveryIntegration.Endpoint = model.Endpoint.ValueString()
 
 	if externalID != nil {
-		discoveryIntegration.EntityDTO.ExternalID = *externalID
+		discoveryIntegration.ExternalID = *externalID
 	}
 
 	if len(model.Tags.Elements()) > 0 {
@@ -332,13 +378,17 @@ func convertDiscoveryIntegrationModelToDTO(ctx context.Context, model models.Dis
 	return discoveryIntegration
 }
 
-func convertDiscoveryIntegrationDTOToModel(ctx context.Context, dto aembit.DiscoveryIntegrationDTO, state models.DiscoveryIntegrationResourceModel) models.DiscoveryIntegrationResourceModel {
+func convertDiscoveryIntegrationDTOToModel(
+	ctx context.Context,
+	dto aembit.DiscoveryIntegrationDTO,
+	state models.DiscoveryIntegrationResourceModel,
+) models.DiscoveryIntegrationResourceModel {
 	var model models.DiscoveryIntegrationResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
 	model.IsActive = types.BoolValue(dto.IsActive)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 	model.Type = types.StringValue(dto.Type)
 	model.SyncFrequencySeconds = types.Int64Value(dto.SyncFrequencySeconds)
 	model.LastSync = types.StringValue(dto.LastSync)

--- a/internal/provider/discovery_integration_resource_test.go
+++ b/internal/provider/discovery_integration_resource_test.go
@@ -10,8 +10,12 @@ import (
 const testDiscoveryIntegrationResourceWiz string = "aembit_discovery_integration.wiz"
 
 func TestAccDiscoveryIntegrationResource_Wiz(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/discovery_integration/wiz/TestAccDiscoveryIntegrationResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/discovery_integration/wiz/TestAccDiscoveryIntegrationResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/discovery_integration/wiz/TestAccDiscoveryIntegrationResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/discovery_integration/wiz/TestAccDiscoveryIntegrationResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -21,7 +25,11 @@ func TestAccDiscoveryIntegrationResource_Wiz(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify AccessCondition Name
-					resource.TestCheckResourceAttr(testDiscoveryIntegrationResourceWiz, "name", "TF Acceptance Wiz"),
+					resource.TestCheckResourceAttr(
+						testDiscoveryIntegrationResourceWiz,
+						"name",
+						"TF Acceptance Wiz",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testDiscoveryIntegrationResourceWiz, "id"),
 					// Verify placeholder ID is set
@@ -29,13 +37,21 @@ func TestAccDiscoveryIntegrationResource_Wiz(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: testDiscoveryIntegrationResourceWiz, ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      testDiscoveryIntegrationResourceWiz,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testDiscoveryIntegrationResourceWiz, "name", "TF Acceptance Wiz - Modified"),
+					resource.TestCheckResourceAttr(
+						testDiscoveryIntegrationResourceWiz,
+						"name",
+						"TF Acceptance Wiz - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/discovery_integrations_data_source.go
+++ b/internal/provider/discovery_integrations_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type discoveryIntegrationsDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *discoveryIntegrationsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *discoveryIntegrationsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *discoveryIntegrationsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *discoveryIntegrationsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_discovery_integrations"
 }
 
 // Schema defines the schema for the resource.
-func (d *discoveryIntegrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *discoveryIntegrationsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages a discovery integration.",
 		Attributes: map[string]schema.Attribute{
@@ -121,7 +133,11 @@ func (d *discoveryIntegrationsDataSource) Schema(_ context.Context, _ datasource
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *discoveryIntegrationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *discoveryIntegrationsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.DiscoveryIntegrationsDataSourceModel
 
 	discoveryIntegrations, err := d.client.GetDiscoveryIntegrations(nil)
@@ -135,7 +151,11 @@ func (d *discoveryIntegrationsDataSource) Read(ctx context.Context, req datasour
 
 	// Map response body to model
 	for _, discoveryIntegration := range discoveryIntegrations {
-		discoveryIntegtationState := convertDiscoveryIntegrationDTOToModel(ctx, discoveryIntegration, models.DiscoveryIntegrationResourceModel{})
+		discoveryIntegtationState := convertDiscoveryIntegrationDTOToModel(
+			ctx,
+			discoveryIntegration,
+			models.DiscoveryIntegrationResourceModel{},
+		)
 		state.DiscoveryIntegrations = append(state.DiscoveryIntegrations, discoveryIntegtationState)
 	}
 

--- a/internal/provider/discovery_integrations_data_source_test.go
+++ b/internal/provider/discovery_integrations_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testDiscoveryIntegrationssDataSource string = "data.aembit_discovery_integrations.test"
-const testDiscoveryIntegrationResource string = "aembit_discovery_integration.wiz"
+const (
+	testDiscoveryIntegrationssDataSource string = "data.aembit_discovery_integrations.test"
+	testDiscoveryIntegrationResource     string = "aembit_discovery_integration.wiz"
+)
 
 func testFindDiscoveryIntegration(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -29,7 +31,9 @@ func testFindDiscoveryIntegration(resourceName string) resource.TestCheckFunc {
 }
 
 func TestAccDiscoveryIntegrationsDataSource(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/discovery_integration/data/TestAccDiscoveryIntegrationsDataSource.tf")
+	createFile, _ := os.ReadFile(
+		"../../tests/discovery_integration/data/TestAccDiscoveryIntegrationsDataSource.tf",
+	)
 	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "TF Acceptance Wiz")
 
 	resource.Test(t, resource.TestCase{
@@ -40,7 +44,10 @@ func TestAccDiscoveryIntegrationsDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Discovery Integrations returned
-					resource.TestCheckResourceAttrSet(testDiscoveryIntegrationssDataSource, "discovery_integrations.#"),
+					resource.TestCheckResourceAttrSet(
+						testDiscoveryIntegrationssDataSource,
+						"discovery_integrations.#",
+					),
 					// Find newly created entry
 					testFindDiscoveryIntegration(testDiscoveryIntegrationResource),
 				),

--- a/internal/provider/global_policy_compliance_data_source.go
+++ b/internal/provider/global_policy_compliance_data_source.go
@@ -3,13 +3,13 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 var (
@@ -26,17 +26,29 @@ func NewGlobalPolicyComplianceDataSource() datasource.DataSource {
 }
 
 // Configure implements datasource.DataSourceWithConfigure.
-func (g *globalPolicyComplianceDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (g *globalPolicyComplianceDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	g.client = datasourceConfigure(req, resp)
 }
 
 // Metadata implements datasource.DataSource.
-func (g *globalPolicyComplianceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (g *globalPolicyComplianceDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_global_policy_compliance_data"
 }
 
 // Read implements datasource.DataSource.
-func (g *globalPolicyComplianceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (g *globalPolicyComplianceDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.GlobalPolicyComplianceModel
 
 	gpcSettingsDto, err := g.client.GetGlobalPolicyComplianceSettings(nil)
@@ -53,7 +65,11 @@ func (g *globalPolicyComplianceDataSource) Read(ctx context.Context, req datasou
 }
 
 // Schema implements datasource.DataSource.
-func (g *globalPolicyComplianceDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (g *globalPolicyComplianceDataSource) Schema(
+	_ context.Context,
+	req datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Contains Global Policy Compliance settings",
 		Attributes: map[string]schema.Attribute{

--- a/internal/provider/global_policy_compliance_data_source_test.go
+++ b/internal/provider/global_policy_compliance_data_source_test.go
@@ -29,10 +29,26 @@ func TestAcc_GPC_DataSource_Read(t *testing.T) {
 				ResourceName: gpcDatasourceName,
 				Config:       gpcDatasourceDef,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(gpcDatasourceName, "access_policy_trust_provider_compliance", "Optional"),
-					resource.TestCheckResourceAttr(gpcDatasourceName, "access_policy_access_condition_compliance", "Optional"),
-					resource.TestCheckResourceAttr(gpcDatasourceName, "agent_controller_trust_provider_compliance", "Optional"),
-					resource.TestCheckResourceAttr(gpcDatasourceName, "agent_controller_allowed_tls_hostname_compliance", "Optional"),
+					resource.TestCheckResourceAttr(
+						gpcDatasourceName,
+						"access_policy_trust_provider_compliance",
+						"Optional",
+					),
+					resource.TestCheckResourceAttr(
+						gpcDatasourceName,
+						"access_policy_access_condition_compliance",
+						"Optional",
+					),
+					resource.TestCheckResourceAttr(
+						gpcDatasourceName,
+						"agent_controller_trust_provider_compliance",
+						"Optional",
+					),
+					resource.TestCheckResourceAttr(
+						gpcDatasourceName,
+						"agent_controller_allowed_tls_hostname_compliance",
+						"Optional",
+					),
 				),
 			},
 		},

--- a/internal/provider/global_policy_compliance_resource.go
+++ b/internal/provider/global_policy_compliance_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 const (
@@ -35,10 +35,17 @@ func NewGlobalPolicyComplianceResource() resource.Resource {
 }
 
 // ImportState implements resource.ResourceWithImportState.
-func (gpcResource *GlobalPolicyComplianceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (gpcResource *GlobalPolicyComplianceResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	gpcSettings, err := gpcResource.client.GetGlobalPolicyComplianceSettings(nil)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to retrieve Global Policy Compliance settings", err.Error())
+		resp.Diagnostics.AddError(
+			"Unable to retrieve Global Policy Compliance settings",
+			err.Error(),
+		)
 		return
 	}
 	state := convertGlobalPolicyComplianceDTOToModel(gpcSettings, gpcResource.client.Tenant)
@@ -46,12 +53,20 @@ func (gpcResource *GlobalPolicyComplianceResource) ImportState(ctx context.Conte
 }
 
 // Configure implements resource.ResourceWithConfigure.
-func (g *GlobalPolicyComplianceResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (g *GlobalPolicyComplianceResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	g.client = resourceConfigure(req, resp)
 }
 
 // Create implements resource.Resource.
-func (g *GlobalPolicyComplianceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (g *GlobalPolicyComplianceResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var gpcModel models.GlobalPolicyComplianceModel
 	diags := req.Plan.Get(ctx, &gpcModel)
@@ -59,16 +74,20 @@ func (g *GlobalPolicyComplianceResource) Create(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.AddWarning("A note about Global Policy Compliance settings",
+	resp.Diagnostics.AddWarning(
+		"A note about Global Policy Compliance settings",
 		`The 'aembit_global_policy_compliance' resource type represents a system-wide collection of settings which already exist
 in Aembit Cloud. This configuration will now manage the existing instance.
 
-Please ensure only one 'resource "aembit_global_policy_compliance" "<name>" {}' block is defined across your entire Terraform configuration.`)
+Please ensure only one 'resource "aembit_global_policy_compliance" "<name>" {}' block is defined across your entire Terraform configuration.`,
+	)
 
 	err := updateComplianceSettings(g.client, &gpcModel, nil)
-
 	if err != nil {
-		resp.Diagnostics.AddError("Error updating Global Policy Compliance settings during resource creation", err.Error())
+		resp.Diagnostics.AddError(
+			"Error updating Global Policy Compliance settings during resource creation",
+			err.Error(),
+		)
 		return
 	}
 	gpcModel.Id = types.StringValue(g.client.Tenant + "-gpc")
@@ -80,9 +99,15 @@ Please ensure only one 'resource "aembit_global_policy_compliance" "<name>" {}' 
 }
 
 // Delete implements resource.Resource.
-func (g *GlobalPolicyComplianceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddWarning("About deleting Global Policy Compliance resource",
-		"Deleting the Global Policy Compliance resource  will result in resetting all settings to their default value ('Recommended')")
+func (g *GlobalPolicyComplianceResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
+	resp.Diagnostics.AddWarning(
+		"About deleting Global Policy Compliance resource",
+		"Deleting the Global Policy Compliance resource  will result in resetting all settings to their default value ('Recommended')",
+	)
 
 	var state models.GlobalPolicyComplianceModel
 	diags := req.State.Get(ctx, &state)
@@ -91,7 +116,7 @@ func (g *GlobalPolicyComplianceResource) Delete(ctx context.Context, req resourc
 		return
 	}
 
-	var defaultModel = models.GlobalPolicyComplianceModel{
+	defaultModel := models.GlobalPolicyComplianceModel{
 		Id:                             types.StringValue(g.client.Tenant + "-gpc"),
 		APTrustProviderCompliance:      types.StringValue("Recommended"),
 		APAccessConditionCompliance:    types.StringValue("Recommended"),
@@ -100,18 +125,29 @@ func (g *GlobalPolicyComplianceResource) Delete(ctx context.Context, req resourc
 	}
 	err := updateComplianceSettings(g.client, &defaultModel, nil)
 	if err != nil {
-		resp.Diagnostics.AddError("Error updating Global Policy Compliance settings to their default values", err.Error())
+		resp.Diagnostics.AddError(
+			"Error updating Global Policy Compliance settings to their default values",
+			err.Error(),
+		)
 		return
 	}
 }
 
 // Metadata implements resource.Resource.
-func (g *GlobalPolicyComplianceResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (g *GlobalPolicyComplianceResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_global_policy_compliance"
 }
 
 // Read implements resource.Resource.
-func (g *GlobalPolicyComplianceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (g *GlobalPolicyComplianceResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	var state models.GlobalPolicyComplianceModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -134,7 +170,11 @@ func (g *GlobalPolicyComplianceResource) Read(ctx context.Context, req resource.
 }
 
 // Schema implements resource.Resource.
-func (g *GlobalPolicyComplianceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (g *GlobalPolicyComplianceResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "A resource to manage the Global Policy Compliance settings",
 		Attributes: map[string]schema.Attribute{
@@ -176,7 +216,11 @@ func (g *GlobalPolicyComplianceResource) Schema(_ context.Context, _ resource.Sc
 }
 
 // Update implements resource.Resource.
-func (g *GlobalPolicyComplianceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (g *GlobalPolicyComplianceResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	var currentModel models.GlobalPolicyComplianceModel
 	diags := req.State.Get(ctx, &currentModel)
 	resp.Diagnostics.Append(diags...)
@@ -192,7 +236,6 @@ func (g *GlobalPolicyComplianceResource) Update(ctx context.Context, req resourc
 	}
 
 	err := updateComplianceSettings(g.client, &updatedModel, &currentModel)
-
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating Global Policy Compliance setting", err.Error())
 		return
@@ -205,7 +248,10 @@ func (g *GlobalPolicyComplianceResource) Update(ctx context.Context, req resourc
 	}
 }
 
-func convertGlobalPolicyComplianceDTOToModel(gpcSettings *aembit.GlobalPolicyComplianceSettingsDTO, tenantId string) models.GlobalPolicyComplianceModel {
+func convertGlobalPolicyComplianceDTOToModel(
+	gpcSettings *aembit.GlobalPolicyComplianceSettingsDTO,
+	tenantId string,
+) models.GlobalPolicyComplianceModel {
 	model := models.GlobalPolicyComplianceModel{}
 	model.Id = types.StringValue(tenantId + "-gpc")
 	for _, settingDto := range *gpcSettings {
@@ -223,24 +269,34 @@ func convertGlobalPolicyComplianceDTOToModel(gpcSettings *aembit.GlobalPolicyCom
 	return model
 }
 
-func convertGlobalPolicyComplianceModelToDTO(model models.GlobalPolicyComplianceModel) aembit.GlobalPolicyComplianceSettingsDTO {
+func convertGlobalPolicyComplianceModelToDTO(
+	model models.GlobalPolicyComplianceModel,
+) aembit.GlobalPolicyComplianceSettingsDTO {
 	dto := aembit.GlobalPolicyComplianceSettingsDTO{}
 	dto = append(dto, aembit.TenantSettingDTO{
 		Name:  AccessPolicyTrustProviderComplianceSettingName,
-		Value: model.APTrustProviderCompliance.ValueString()})
+		Value: model.APTrustProviderCompliance.ValueString(),
+	})
 	dto = append(dto, aembit.TenantSettingDTO{
 		Name:  AccessPolicyAccessConditionComplianceSettingName,
-		Value: model.APAccessConditionCompliance.ValueString()})
+		Value: model.APAccessConditionCompliance.ValueString(),
+	})
 	dto = append(dto, aembit.TenantSettingDTO{
 		Name:  AgentControllerTrustProviderComplianceSettingName,
-		Value: model.ACTrustProviderCompliance.ValueString()})
+		Value: model.ACTrustProviderCompliance.ValueString(),
+	})
 	dto = append(dto, aembit.TenantSettingDTO{
 		Name:  AgentControllerTlsHostNameComplianceSettingName,
-		Value: model.ACAllowedTLSHostanmeCompliance.ValueString()})
+		Value: model.ACAllowedTLSHostanmeCompliance.ValueString(),
+	})
 	return dto
 }
 
-func updateComplianceSettings(client *aembit.CloudClient, currentModel *models.GlobalPolicyComplianceModel, previousModel *models.GlobalPolicyComplianceModel) error {
+func updateComplianceSettings(
+	client *aembit.CloudClient,
+	currentModel *models.GlobalPolicyComplianceModel,
+	previousModel *models.GlobalPolicyComplianceModel,
+) error {
 	if previousModel == nil {
 		dto := convertGlobalPolicyComplianceModelToDTO(*currentModel)
 		for _, settingDto := range dto {
@@ -258,28 +314,58 @@ func updateComplianceSettings(client *aembit.CloudClient, currentModel *models.G
 	return nil
 }
 
-func compareAndUpdate(client *aembit.CloudClient, currentModel *models.GlobalPolicyComplianceModel, previousModel *models.GlobalPolicyComplianceModel) error {
-	//update only what has changed
+func compareAndUpdate(
+	client *aembit.CloudClient,
+	currentModel *models.GlobalPolicyComplianceModel,
+	previousModel *models.GlobalPolicyComplianceModel,
+) error {
+	// update only what has changed
 	if !currentModel.APTrustProviderCompliance.Equal(previousModel.APTrustProviderCompliance) {
-		_, err := client.UpdateGlobalPolicyComplianceSetting(aembit.TenantSettingDTO{Name: AccessPolicyTrustProviderComplianceSettingName, Value: currentModel.APTrustProviderCompliance.ValueString()}, nil)
+		_, err := client.UpdateGlobalPolicyComplianceSetting(
+			aembit.TenantSettingDTO{
+				Name:  AccessPolicyTrustProviderComplianceSettingName,
+				Value: currentModel.APTrustProviderCompliance.ValueString(),
+			},
+			nil,
+		)
 		if err != nil {
 			return err
 		}
 	}
 	if !currentModel.APAccessConditionCompliance.Equal(previousModel.APAccessConditionCompliance) {
-		_, err := client.UpdateGlobalPolicyComplianceSetting(aembit.TenantSettingDTO{Name: AccessPolicyAccessConditionComplianceSettingName, Value: currentModel.APAccessConditionCompliance.ValueString()}, nil)
+		_, err := client.UpdateGlobalPolicyComplianceSetting(
+			aembit.TenantSettingDTO{
+				Name:  AccessPolicyAccessConditionComplianceSettingName,
+				Value: currentModel.APAccessConditionCompliance.ValueString(),
+			},
+			nil,
+		)
 		if err != nil {
 			return err
 		}
 	}
 	if !currentModel.ACTrustProviderCompliance.Equal(previousModel.ACTrustProviderCompliance) {
-		_, err := client.UpdateGlobalPolicyComplianceSetting(aembit.TenantSettingDTO{Name: AgentControllerTrustProviderComplianceSettingName, Value: currentModel.ACTrustProviderCompliance.ValueString()}, nil)
+		_, err := client.UpdateGlobalPolicyComplianceSetting(
+			aembit.TenantSettingDTO{
+				Name:  AgentControllerTrustProviderComplianceSettingName,
+				Value: currentModel.ACTrustProviderCompliance.ValueString(),
+			},
+			nil,
+		)
 		if err != nil {
 			return err
 		}
 	}
-	if !currentModel.ACAllowedTLSHostanmeCompliance.Equal(previousModel.ACAllowedTLSHostanmeCompliance) {
-		_, err := client.UpdateGlobalPolicyComplianceSetting(aembit.TenantSettingDTO{Name: AgentControllerTlsHostNameComplianceSettingName, Value: currentModel.ACAllowedTLSHostanmeCompliance.ValueString()}, nil)
+	if !currentModel.ACAllowedTLSHostanmeCompliance.Equal(
+		previousModel.ACAllowedTLSHostanmeCompliance,
+	) {
+		_, err := client.UpdateGlobalPolicyComplianceSetting(
+			aembit.TenantSettingDTO{
+				Name:  AgentControllerTlsHostNameComplianceSettingName,
+				Value: currentModel.ACAllowedTLSHostanmeCompliance.ValueString(),
+			},
+			nil,
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/global_policy_compliance_resource_test.go
+++ b/internal/provider/global_policy_compliance_resource_test.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"terraform-provider-aembit/internal/provider/models"
 	"testing"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 func TestAcc_GPC_CreateImportUpdate(t *testing.T) {
@@ -39,10 +39,26 @@ func TestAcc_GPC_CreateImportUpdate(t *testing.T) {
 				ResourceName: gpcResourceName,
 				Config:       gpcResourceDef,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(gpcResourceName, "access_policy_trust_provider_compliance", "Recommended"),
-					resource.TestCheckResourceAttr(gpcResourceName, "access_policy_access_condition_compliance", "Recommended"),
-					resource.TestCheckResourceAttr(gpcResourceName, "agent_controller_trust_provider_compliance", "Recommended"),
-					resource.TestCheckResourceAttr(gpcResourceName, "agent_controller_allowed_tls_hostname_compliance", "Recommended"),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"access_policy_trust_provider_compliance",
+						"Recommended",
+					),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"access_policy_access_condition_compliance",
+						"Recommended",
+					),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"agent_controller_trust_provider_compliance",
+						"Recommended",
+					),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"agent_controller_allowed_tls_hostname_compliance",
+						"Recommended",
+					),
 				),
 			},
 			// ImportState testing
@@ -52,10 +68,26 @@ func TestAcc_GPC_CreateImportUpdate(t *testing.T) {
 				ResourceName: gpcResourceName,
 				Config:       gpcResourceUpdate,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(gpcResourceName, "access_policy_trust_provider_compliance", "Optional"),
-					resource.TestCheckResourceAttr(gpcResourceName, "access_policy_access_condition_compliance", "Optional"),
-					resource.TestCheckResourceAttr(gpcResourceName, "agent_controller_trust_provider_compliance", "Optional"),
-					resource.TestCheckResourceAttr(gpcResourceName, "agent_controller_allowed_tls_hostname_compliance", "Optional"),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"access_policy_trust_provider_compliance",
+						"Optional",
+					),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"access_policy_access_condition_compliance",
+						"Optional",
+					),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"agent_controller_trust_provider_compliance",
+						"Optional",
+					),
+					resource.TestCheckResourceAttr(
+						gpcResourceName,
+						"agent_controller_allowed_tls_hostname_compliance",
+						"Optional",
+					),
 				),
 			},
 		},
@@ -74,17 +106,39 @@ func Test_GPC_convertGlobalPolicyComplianceDTOToModel(t *testing.T) {
 		{
 			name: "success",
 			args: args{gpcSettings: &aembit.GlobalPolicyComplianceSettingsDTO{
-				aembit.TenantSettingDTO{Name: AccessPolicyTrustProviderComplianceSettingName, Value: "Required"},
-				aembit.TenantSettingDTO{Name: AccessPolicyAccessConditionComplianceSettingName, Value: "Required"},
-				aembit.TenantSettingDTO{Name: AgentControllerTrustProviderComplianceSettingName, Value: "Required"},
-				aembit.TenantSettingDTO{Name: AgentControllerTlsHostNameComplianceSettingName, Value: "Required"}}},
-			want: models.GlobalPolicyComplianceModel{Id: types.StringValue("testId-gpc"), APTrustProviderCompliance: types.StringValue("Required"), APAccessConditionCompliance: types.StringValue("Required"),
-				ACTrustProviderCompliance: types.StringValue("Required"), ACAllowedTLSHostanmeCompliance: types.StringValue("Required")},
+				aembit.TenantSettingDTO{
+					Name:  AccessPolicyTrustProviderComplianceSettingName,
+					Value: "Required",
+				},
+				aembit.TenantSettingDTO{
+					Name:  AccessPolicyAccessConditionComplianceSettingName,
+					Value: "Required",
+				},
+				aembit.TenantSettingDTO{
+					Name:  AgentControllerTrustProviderComplianceSettingName,
+					Value: "Required",
+				},
+				aembit.TenantSettingDTO{
+					Name:  AgentControllerTlsHostNameComplianceSettingName,
+					Value: "Required",
+				},
+			}},
+			want: models.GlobalPolicyComplianceModel{
+				Id: types.StringValue(
+					"testId-gpc",
+				), APTrustProviderCompliance: types.StringValue("Required"), APAccessConditionCompliance: types.StringValue("Required"),
+				ACTrustProviderCompliance: types.StringValue(
+					"Required",
+				), ACAllowedTLSHostanmeCompliance: types.StringValue("Required"),
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := convertGlobalPolicyComplianceDTOToModel(tt.args.gpcSettings, "testId"); !reflect.DeepEqual(got, tt.want) {
+			if got := convertGlobalPolicyComplianceDTOToModel(tt.args.gpcSettings, "testId"); !reflect.DeepEqual(
+				got,
+				tt.want,
+			) {
 				t.Errorf("convertGlobalPolicyComplianceDTOToModel() = %v, want %v", got, tt.want)
 			}
 		})
@@ -106,16 +160,31 @@ func Test_GPC_convertGlobalPolicyComplianceModelToDTO(t *testing.T) {
 				ACAllowedTLSHostanmeCompliance: types.StringValue("Required"),
 			},
 			want: aembit.GlobalPolicyComplianceSettingsDTO{
-				aembit.TenantSettingDTO{Name: AccessPolicyTrustProviderComplianceSettingName, Value: "Required"},
-				aembit.TenantSettingDTO{Name: AccessPolicyAccessConditionComplianceSettingName, Value: "Required"},
-				aembit.TenantSettingDTO{Name: AgentControllerTrustProviderComplianceSettingName, Value: "Required"},
-				aembit.TenantSettingDTO{Name: AgentControllerTlsHostNameComplianceSettingName, Value: "Required"},
+				aembit.TenantSettingDTO{
+					Name:  AccessPolicyTrustProviderComplianceSettingName,
+					Value: "Required",
+				},
+				aembit.TenantSettingDTO{
+					Name:  AccessPolicyAccessConditionComplianceSettingName,
+					Value: "Required",
+				},
+				aembit.TenantSettingDTO{
+					Name:  AgentControllerTrustProviderComplianceSettingName,
+					Value: "Required",
+				},
+				aembit.TenantSettingDTO{
+					Name:  AgentControllerTlsHostNameComplianceSettingName,
+					Value: "Required",
+				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := convertGlobalPolicyComplianceModelToDTO(tt.model); !reflect.DeepEqual(got, tt.want) {
+			if got := convertGlobalPolicyComplianceModelToDTO(tt.model); !reflect.DeepEqual(
+				got,
+				tt.want,
+			) {
 				t.Errorf("convertGlobalPolicyComplianceModelToDTO() = %v, want %v", got, tt.want)
 			}
 		})
@@ -137,47 +206,67 @@ func Test_GPC_updateComplianceSettings_API_Errors(t *testing.T) {
 			name: "api_error_no_previous_state",
 			args: args{
 				currentModel: &models.GlobalPolicyComplianceModel{},
-				//this indicates that there is no previous state
-				previousModel: nil},
-			wantErr: true},
+				// this indicates that there is no previous state
+				previousModel: nil,
+			},
+			wantErr: true,
+		},
 		{
 			name: "api_error_when_updating_ap_tp",
 			args: args{
-				currentModel:  &models.GlobalPolicyComplianceModel{APTrustProviderCompliance: types.StringValue("Value")},
-				previousModel: &models.GlobalPolicyComplianceModel{APTrustProviderCompliance: types.StringValue("ADifferentValue")},
+				currentModel: &models.GlobalPolicyComplianceModel{
+					APTrustProviderCompliance: types.StringValue("Value"),
+				},
+				previousModel: &models.GlobalPolicyComplianceModel{
+					APTrustProviderCompliance: types.StringValue("ADifferentValue"),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "api_error_when_updating_ap_ac",
 			args: args{
-				currentModel:  &models.GlobalPolicyComplianceModel{APAccessConditionCompliance: types.StringValue("Value")},
-				previousModel: &models.GlobalPolicyComplianceModel{APAccessConditionCompliance: types.StringValue("ADifferentValue")},
+				currentModel: &models.GlobalPolicyComplianceModel{
+					APAccessConditionCompliance: types.StringValue("Value"),
+				},
+				previousModel: &models.GlobalPolicyComplianceModel{
+					APAccessConditionCompliance: types.StringValue("ADifferentValue"),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "api_error_when_updating_ac_tp",
 			args: args{
-				currentModel:  &models.GlobalPolicyComplianceModel{ACTrustProviderCompliance: types.StringValue("Value")},
-				previousModel: &models.GlobalPolicyComplianceModel{ACTrustProviderCompliance: types.StringValue("ADifferentValue")},
+				currentModel: &models.GlobalPolicyComplianceModel{
+					ACTrustProviderCompliance: types.StringValue("Value"),
+				},
+				previousModel: &models.GlobalPolicyComplianceModel{
+					ACTrustProviderCompliance: types.StringValue("ADifferentValue"),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "api_error_when_updating_ap_tls",
 			args: args{
-				currentModel:  &models.GlobalPolicyComplianceModel{ACAllowedTLSHostanmeCompliance: types.StringValue("Value")},
-				previousModel: &models.GlobalPolicyComplianceModel{ACAllowedTLSHostanmeCompliance: types.StringValue("ADifferentValue")},
+				currentModel: &models.GlobalPolicyComplianceModel{
+					ACAllowedTLSHostanmeCompliance: types.StringValue("Value"),
+				},
+				previousModel: &models.GlobalPolicyComplianceModel{
+					ACAllowedTLSHostanmeCompliance: types.StringValue("ADifferentValue"),
+				},
 			},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusBadRequest)
-			}))
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusBadRequest)
+				}),
+			)
 			defer server.Close()
 
 			c, _ := aembit.NewClient(&aembit.URLBuilder{}, nil, "", "test")

--- a/internal/provider/integration_data_source.go
+++ b/internal/provider/integration_data_source.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -29,17 +29,29 @@ type integrationsDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *integrationsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *integrationsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *integrationsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *integrationsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_integrations"
 }
 
 // Schema defines the schema for the resource.
-func (d *integrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *integrationsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages an integration.",
 		Attributes: map[string]schema.Attribute{
@@ -47,7 +59,8 @@ func (d *integrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				Optional:    true,
 				Description: "Filter integrations by type (either `AembitTimeCondition` or `AembitGeoIPCondition`)",
 				Validators: []validator.String{
-					stringvalidator.OneOf([]string{"AembitTimeCondition", "AembitGeoIPCondition"}...),
+					stringvalidator.OneOf(
+						[]string{"AembitTimeCondition", "AembitGeoIPCondition"}...),
 				},
 			},
 			"integrations": schema.ListNestedAttribute{
@@ -81,7 +94,8 @@ func (d *integrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 							Description: "Type of Aembit integration (either `WizIntegrationApi` or `CrowdStrike`).",
 							Computed:    true,
 							Validators: []validator.String{
-								stringvalidator.OneOf([]string{"WizIntegrationApi", "CrowdStrike"}...),
+								stringvalidator.OneOf(
+									[]string{"WizIntegrationApi", "CrowdStrike"}...),
 							},
 						},
 						"sync_frequency": schema.Int64Attribute{
@@ -113,13 +127,16 @@ func (d *integrationsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *integrationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *integrationsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.IntegrationsDataSourceModel
 
 	req.Config.Get(ctx, &state)
 
 	integrations, err := d.client.GetIntegrations(nil)
-
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Aembit Integrations",
@@ -137,7 +154,11 @@ func (d *integrationsDataSource) Read(ctx context.Context, req datasource.ReadRe
 			}
 		}
 
-		integrationState := convertIntegrationDTOToModel(ctx, integration, models.IntegrationResourceModel{})
+		integrationState := convertIntegrationDTOToModel(
+			ctx,
+			integration,
+			models.IntegrationResourceModel{},
+		)
 		state.Integrations = append(state.Integrations, integrationState)
 	}
 

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -12,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -32,17 +32,29 @@ type integrationResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *integrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *integrationResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_integration"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *integrationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *integrationResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *integrationResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -127,7 +139,11 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *integrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *integrationResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.IntegrationResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -137,7 +153,7 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Generate API request body from plan
-	var dto aembit.IntegrationDTO = convertIntegrationModelToDTO(ctx, plan, nil)
+	dto := convertIntegrationModelToDTO(ctx, plan, nil)
 
 	// Create new Integration
 	integration, err := r.client.CreateIntegration(dto, nil)
@@ -161,7 +177,11 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *integrationResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.IntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -196,7 +216,11 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *integrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *integrationResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.IntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -217,7 +241,7 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	// Generate API request body from plan
-	var dto aembit.IntegrationDTO = convertIntegrationModelToDTO(ctx, plan, &externalID)
+	dto := convertIntegrationModelToDTO(ctx, plan, &externalID)
 
 	// Update Integration
 	integration, err := r.client.UpdateIntegration(dto, nil)
@@ -241,7 +265,11 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *integrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *integrationResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.IntegrationResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -274,12 +302,20 @@ func (r *integrationResource) Delete(ctx context.Context, req resource.DeleteReq
 }
 
 // Imports an existing resource by passing externalId.
-func (r *integrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *integrationResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertIntegrationModelToDTO(ctx context.Context, model models.IntegrationResourceModel, externalID *string) aembit.IntegrationDTO {
+func convertIntegrationModelToDTO(
+	ctx context.Context,
+	model models.IntegrationResourceModel,
+	externalID *string,
+) aembit.IntegrationDTO {
 	var integration aembit.IntegrationDTO
 	integration.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -299,7 +335,7 @@ func convertIntegrationModelToDTO(ctx context.Context, model models.IntegrationR
 	}
 
 	if externalID != nil {
-		integration.EntityDTO.ExternalID = *externalID
+		integration.ExternalID = *externalID
 	}
 
 	integration.Endpoint = model.Endpoint.ValueString()
@@ -315,13 +351,17 @@ func convertIntegrationModelToDTO(ctx context.Context, model models.IntegrationR
 	return integration
 }
 
-func convertIntegrationDTOToModel(ctx context.Context, dto aembit.IntegrationDTO, state models.IntegrationResourceModel) models.IntegrationResourceModel {
+func convertIntegrationDTOToModel(
+	ctx context.Context,
+	dto aembit.IntegrationDTO,
+	state models.IntegrationResourceModel,
+) models.IntegrationResourceModel {
 	var model models.IntegrationResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 
 	model.Type = types.StringValue(dto.Type)
 	model.Endpoint = types.StringValue(dto.Endpoint)

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testIntegrationWiz string = "aembit_integration.wiz"
-const testIntegrationCrowdstrike string = "aembit_integration.crowdstrike"
+const (
+	testIntegrationWiz         string = "aembit_integration.wiz"
+	testIntegrationCrowdstrike string = "aembit_integration.crowdstrike"
+)
 
 func testDeleteIntegration(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -52,7 +54,11 @@ func TestAccIntegrationResource_Wiz(t *testing.T) {
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteIntegration(testIntegrationWiz), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteIntegration(testIntegrationWiz),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
@@ -62,7 +68,11 @@ func TestAccIntegrationResource_Wiz(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testIntegrationWiz, "name", "TF Acceptance Wiz - Modified"),
+					resource.TestCheckResourceAttr(
+						testIntegrationWiz,
+						"name",
+						"TF Acceptance Wiz - Modified",
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testIntegrationWiz, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testIntegrationWiz, tagsColor, "orange"),
@@ -75,8 +85,12 @@ func TestAccIntegrationResource_Wiz(t *testing.T) {
 }
 
 func TestAccIntegrationResource_Crowdstrike(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/integration/crowdstrike/TestAccIntegrationResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/integration/crowdstrike/TestAccIntegrationResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/integration/crowdstrike/TestAccIntegrationResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/integration/crowdstrike/TestAccIntegrationResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -86,7 +100,11 @@ func TestAccIntegrationResource_Crowdstrike(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Integration Name
-					resource.TestCheckResourceAttr(testIntegrationCrowdstrike, "name", "TF Acceptance Crowdstrike"),
+					resource.TestCheckResourceAttr(
+						testIntegrationCrowdstrike,
+						"name",
+						"TF Acceptance Crowdstrike",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testIntegrationCrowdstrike, "id"),
 					// Verify placeholder ID is set
@@ -100,7 +118,11 @@ func TestAccIntegrationResource_Crowdstrike(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testIntegrationCrowdstrike, "name", "TF Acceptance Crowdstrike - Modified"),
+					resource.TestCheckResourceAttr(
+						testIntegrationCrowdstrike,
+						"name",
+						"TF Acceptance Crowdstrike - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/integrations_data_source_test.go
+++ b/internal/provider/integrations_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testIntegrationsDataSource string = "data.aembit_integrations.test"
-const testIntegrationResource string = "aembit_integration.wiz"
+const (
+	testIntegrationsDataSource string = "data.aembit_integrations.test"
+	testIntegrationResource    string = "aembit_integration.wiz"
+)
 
 func testFindIntegration(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -42,7 +44,10 @@ func TestAccIntegrationsDataSource(t *testing.T) {
 					// Verify non-zero number of Integrations returned
 					resource.TestCheckResourceAttrSet(testIntegrationsDataSource, "integrations.#"),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testIntegrationsDataSource, "integrations.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testIntegrationsDataSource,
+						"integrations.0.id",
+					),
 					// Find newly created entry
 					testFindIntegration(testIntegrationResource),
 				),

--- a/internal/provider/log_stream_resource.go
+++ b/internal/provider/log_stream_resource.go
@@ -321,7 +321,7 @@ func (r *logStreamResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// Generate API request body from plan
-	var dto aembit.LogStreamDTO = convertLogStreamModelToDTO(plan, &externalID)
+	var dto = convertLogStreamModelToDTO(plan, &externalID)
 
 	// Update Log Stream
 	logStream, err := r.client.UpdateLogStream(dto, nil)

--- a/internal/provider/log_stream_resource.go
+++ b/internal/provider/log_stream_resource.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -14,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -34,17 +34,29 @@ type logStreamResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *logStreamResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *logStreamResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_log_stream"
 }
 
 // Configure adds the log stream to the resource.
-func (r *logStreamResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *logStreamResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *logStreamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *logStreamResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -231,7 +243,11 @@ func (r *logStreamResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *logStreamResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *logStreamResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.LogStreamResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -241,7 +257,7 @@ func (r *logStreamResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Generate API request body from plan
-	var dto aembit.LogStreamDTO = convertLogStreamModelToDTO(plan, nil)
+	dto := convertLogStreamModelToDTO(plan, nil)
 
 	// Create new log stream
 	logStream, err := r.client.CreateLogStream(dto, nil)
@@ -265,7 +281,11 @@ func (r *logStreamResource) Create(ctx context.Context, req resource.CreateReque
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *logStreamResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *logStreamResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.LogStreamResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -300,7 +320,11 @@ func (r *logStreamResource) Read(ctx context.Context, req resource.ReadRequest, 
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *logStreamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *logStreamResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.LogStreamResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -321,7 +345,7 @@ func (r *logStreamResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// Generate API request body from plan
-	var dto = convertLogStreamModelToDTO(plan, &externalID)
+	dto := convertLogStreamModelToDTO(plan, &externalID)
 
 	// Update Log Stream
 	logStream, err := r.client.UpdateLogStream(dto, nil)
@@ -345,7 +369,11 @@ func (r *logStreamResource) Update(ctx context.Context, req resource.UpdateReque
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *logStreamResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *logStreamResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.LogStreamResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -366,12 +394,19 @@ func (r *logStreamResource) Delete(ctx context.Context, req resource.DeleteReque
 }
 
 // Imports an existing resource by passing externalId.
-func (r *logStreamResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *logStreamResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertLogStreamModelToDTO(model models.LogStreamResourceModel, externalID *string) aembit.LogStreamDTO {
+func convertLogStreamModelToDTO(
+	model models.LogStreamResourceModel,
+	externalID *string,
+) aembit.LogStreamDTO {
 	var logStream aembit.LogStreamDTO
 	logStream.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -380,7 +415,7 @@ func convertLogStreamModelToDTO(model models.LogStreamResourceModel, externalID 
 	}
 
 	if externalID != nil {
-		logStream.EntityDTO.ExternalID = *externalID
+		logStream.ExternalID = *externalID
 	}
 
 	logStream.DataType = model.DataType.ValueString()
@@ -419,12 +454,15 @@ func convertLogStreamModelToDTO(model models.LogStreamResourceModel, externalID 
 	return logStream
 }
 
-func convertLogStreamDTOToModel(dto aembit.LogStreamDTO, state models.LogStreamResourceModel) models.LogStreamResourceModel {
+func convertLogStreamDTOToModel(
+	dto aembit.LogStreamDTO,
+	state models.LogStreamResourceModel,
+) models.LogStreamResourceModel {
 	var model models.LogStreamResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
 
 	model.DataType = types.StringValue(dto.DataType)
 	model.Type = types.StringValue(dto.Type)
@@ -456,7 +494,9 @@ func convertLogStreamDTOToModel(dto aembit.LogStreamDTO, state models.LogStreamR
 		}
 
 		if dto.AuthenticationToken != "" {
-			model.SplunkHttpEventCollector.AuthenticationToken = types.StringValue(dto.AuthenticationToken)
+			model.SplunkHttpEventCollector.AuthenticationToken = types.StringValue(
+				dto.AuthenticationToken,
+			)
 		} else if state.SplunkHttpEventCollector != nil {
 			model.SplunkHttpEventCollector.AuthenticationToken = state.SplunkHttpEventCollector.AuthenticationToken
 		} else {

--- a/internal/provider/log_stream_resource_test.go
+++ b/internal/provider/log_stream_resource_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testLogStreamAWSS3Bucket string = "aembit_log_stream.aws_s3_bucket"
-const testLogStreamGCSBucket string = "aembit_log_stream.gcs_bucket"
-const testLogStreamSplunkHttpEventCollector string = "aembit_log_stream.splunk_http_event_collector"
-const testLogStreamCrowdstrikeHttpEventCollector string = "aembit_log_stream.crowdstrike_http_event_collector"
+const (
+	testLogStreamAWSS3Bucket                   string = "aembit_log_stream.aws_s3_bucket"
+	testLogStreamGCSBucket                     string = "aembit_log_stream.gcs_bucket"
+	testLogStreamSplunkHttpEventCollector      string = "aembit_log_stream.splunk_http_event_collector"
+	testLogStreamCrowdstrikeHttpEventCollector string = "aembit_log_stream.crowdstrike_http_event_collector"
+)
 
 func testDeleteLogStream(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -32,7 +34,9 @@ func testDeleteLogStream(resourceName string) resource.TestCheckFunc {
 
 func TestAccLogStreamResource_AWSS3Bucket(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/log_stream/awsS3Bucket/TestAccLogStreamResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/log_stream/awsS3Bucket/TestAccLogStreamResource.tfmod")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/log_stream/awsS3Bucket/TestAccLogStreamResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -42,7 +46,11 @@ func TestAccLogStreamResource_AWSS3Bucket(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify LogStream Name
-					resource.TestCheckResourceAttr(testLogStreamAWSS3Bucket, "name", "TF Acceptance AWSS3Bucket LogStream"),
+					resource.TestCheckResourceAttr(
+						testLogStreamAWSS3Bucket,
+						"name",
+						"TF Acceptance AWSS3Bucket LogStream",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testLogStreamAWSS3Bucket, "id"),
 					// Verify placeholder ID is set
@@ -50,7 +58,11 @@ func TestAccLogStreamResource_AWSS3Bucket(t *testing.T) {
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteLogStream(testLogStreamAWSS3Bucket), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteLogStream(testLogStreamAWSS3Bucket),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
@@ -60,7 +72,11 @@ func TestAccLogStreamResource_AWSS3Bucket(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testLogStreamAWSS3Bucket, "name", "TF Acceptance AWSS3Bucket LogStream - Modified"),
+					resource.TestCheckResourceAttr(
+						testLogStreamAWSS3Bucket,
+						"name",
+						"TF Acceptance AWSS3Bucket LogStream - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -80,7 +96,11 @@ func TestAccLogStreamResource_GCSBucket(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify LogStream Name
-					resource.TestCheckResourceAttr(testLogStreamGCSBucket, "name", "TF Acceptance GCSBucket LogStream"),
+					resource.TestCheckResourceAttr(
+						testLogStreamGCSBucket,
+						"name",
+						"TF Acceptance GCSBucket LogStream",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testLogStreamGCSBucket, "id"),
 					// Verify placeholder ID is set
@@ -88,7 +108,11 @@ func TestAccLogStreamResource_GCSBucket(t *testing.T) {
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteLogStream(testLogStreamGCSBucket), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteLogStream(testLogStreamGCSBucket),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
@@ -98,7 +122,11 @@ func TestAccLogStreamResource_GCSBucket(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testLogStreamGCSBucket, "name", "TF Acceptance GCSBucket LogStream - Modified"),
+					resource.TestCheckResourceAttr(
+						testLogStreamGCSBucket,
+						"name",
+						"TF Acceptance GCSBucket LogStream - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -107,8 +135,12 @@ func TestAccLogStreamResource_GCSBucket(t *testing.T) {
 }
 
 func TestAccLogStreamResource_Splunk(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/log_stream/splunkHttpEventCollector/TestAccLogStreamResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/log_stream/splunkHttpEventCollector/TestAccLogStreamResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/log_stream/splunkHttpEventCollector/TestAccLogStreamResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/log_stream/splunkHttpEventCollector/TestAccLogStreamResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -118,7 +150,11 @@ func TestAccLogStreamResource_Splunk(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify LogStream Name
-					resource.TestCheckResourceAttr(testLogStreamSplunkHttpEventCollector, "name", "TF Acceptance SplunkHttpEventCollector LogStream"),
+					resource.TestCheckResourceAttr(
+						testLogStreamSplunkHttpEventCollector,
+						"name",
+						"TF Acceptance SplunkHttpEventCollector LogStream",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testLogStreamSplunkHttpEventCollector, "id"),
 					// Verify placeholder ID is set
@@ -126,17 +162,29 @@ func TestAccLogStreamResource_Splunk(t *testing.T) {
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteLogStream(testLogStreamSplunkHttpEventCollector), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteLogStream(testLogStreamSplunkHttpEventCollector),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
-			{ResourceName: testLogStreamSplunkHttpEventCollector, ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      testLogStreamSplunkHttpEventCollector,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testLogStreamSplunkHttpEventCollector, "name", "TF Acceptance SplunkHttpEventCollector LogStream - Modified"),
+					resource.TestCheckResourceAttr(
+						testLogStreamSplunkHttpEventCollector,
+						"name",
+						"TF Acceptance SplunkHttpEventCollector LogStream - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -145,8 +193,12 @@ func TestAccLogStreamResource_Splunk(t *testing.T) {
 }
 
 func TestAccLogStreamResource_Crowdstrike(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/log_stream/crowdstrikeHttpEventCollector/TestAccLogStreamResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/log_stream/crowdstrikeHttpEventCollector/TestAccLogStreamResource.tfmod")
+	createFile, _ := os.ReadFile(
+		"../../tests/log_stream/crowdstrikeHttpEventCollector/TestAccLogStreamResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/log_stream/crowdstrikeHttpEventCollector/TestAccLogStreamResource.tfmod",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -156,25 +208,47 @@ func TestAccLogStreamResource_Crowdstrike(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify LogStream Name
-					resource.TestCheckResourceAttr(testLogStreamCrowdstrikeHttpEventCollector, "name", "TF Acceptance CrowdstrikeHttpEventCollector LogStream"),
+					resource.TestCheckResourceAttr(
+						testLogStreamCrowdstrikeHttpEventCollector,
+						"name",
+						"TF Acceptance CrowdstrikeHttpEventCollector LogStream",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testLogStreamCrowdstrikeHttpEventCollector, "id"),
+					resource.TestCheckResourceAttrSet(
+						testLogStreamCrowdstrikeHttpEventCollector,
+						"id",
+					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet(testLogStreamCrowdstrikeHttpEventCollector, "id"),
+					resource.TestCheckResourceAttrSet(
+						testLogStreamCrowdstrikeHttpEventCollector,
+						"id",
+					),
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteLogStream(testLogStreamCrowdstrikeHttpEventCollector), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteLogStream(testLogStreamCrowdstrikeHttpEventCollector),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
-			{ResourceName: testLogStreamCrowdstrikeHttpEventCollector, ImportState: true, ImportStateVerify: false},
+			{
+				ResourceName:      testLogStreamCrowdstrikeHttpEventCollector,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testLogStreamCrowdstrikeHttpEventCollector, "name", "TF Acceptance CrowdstrikeHttpEventCollector LogStream - Modified"),
+					resource.TestCheckResourceAttr(
+						testLogStreamCrowdstrikeHttpEventCollector,
+						"name",
+						"TF Acceptance CrowdstrikeHttpEventCollector LogStream - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/log_streams_data_source.go
+++ b/internal/provider/log_streams_data_source.go
@@ -2,11 +2,11 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -26,17 +26,29 @@ type logStreamsDataSource struct {
 }
 
 // Configure adds the logStream to the data source.
-func (d *logStreamsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *logStreamsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *logStreamsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *logStreamsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_log_streams"
 }
 
 // Schema defines the schema for the resource.
-func (d *logStreamsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *logStreamsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Use this data source to get information about all Aembit Log Streams",
 		Attributes: map[string]schema.Attribute{
@@ -166,7 +178,11 @@ func (d *logStreamsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *logStreamsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *logStreamsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.LogStreamsDataSourceModel
 
 	logStreams, err := d.client.GetLogStreams(nil)

--- a/internal/provider/log_streams_data_source_test.go
+++ b/internal/provider/log_streams_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testLogStreamsDataSource string = "data.aembit_log_streams.test"
-const testLogStreamResource string = "aembit_log_stream.aws_s3_bucket"
+const (
+	testLogStreamsDataSource string = "data.aembit_log_streams.test"
+	testLogStreamResource    string = "aembit_log_stream.aws_s3_bucket"
+)
 
 func testFindLogStream(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -30,7 +32,11 @@ func testFindLogStream(resourceName string) resource.TestCheckFunc {
 
 func TestAccLogStreamsDataSource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/log_stream/data/TestAccLogStreamsDataSource.tf")
-	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "TF Acceptance AWSS3Bucket LogStream")
+	createFileConfig, _, _ := randomizeFileConfigs(
+		string(createFile),
+		"",
+		"TF Acceptance AWSS3Bucket LogStream",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -59,7 +59,10 @@ type aembitProvider struct {
 }
 
 // Configure adds the provider configured client to the resource.
-func resourceConfigure(req resource.ConfigureRequest, resp *resource.ConfigureResponse) *aembit.CloudClient {
+func resourceConfigure(
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) *aembit.CloudClient {
 	if req.ProviderData == nil {
 		return nil
 	}
@@ -69,7 +72,10 @@ func resourceConfigure(req resource.ConfigureRequest, resp *resource.ConfigureRe
 	if client, ok = req.ProviderData.(*aembit.CloudClient); !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configuration Type",
-			fmt.Sprintf("Expected *aembit.CloudClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf(
+				"Expected *aembit.CloudClient, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData,
+			),
 		)
 
 		return nil
@@ -79,7 +85,10 @@ func resourceConfigure(req resource.ConfigureRequest, resp *resource.ConfigureRe
 }
 
 // Configure adds the provider configured client to the data source.
-func datasourceConfigure(req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *aembit.CloudClient {
+func datasourceConfigure(
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) *aembit.CloudClient {
 	if req.ProviderData == nil {
 		return nil
 	}
@@ -89,7 +98,10 @@ func datasourceConfigure(req datasource.ConfigureRequest, resp *datasource.Confi
 	if client, ok = req.ProviderData.(*aembit.CloudClient); !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configuration Type",
-			fmt.Sprintf("Expected *aembit.CloudClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf(
+				"Expected *aembit.CloudClient, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData,
+			),
 		)
 
 		return nil
@@ -99,13 +111,21 @@ func datasourceConfigure(req datasource.ConfigureRequest, resp *datasource.Confi
 }
 
 // Metadata returns the provider type name.
-func (p *aembitProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+func (p *aembitProvider) Metadata(
+	_ context.Context,
+	_ provider.MetadataRequest,
+	resp *provider.MetadataResponse,
+) {
 	resp.TypeName = "aembit"
 	resp.Version = p.version
 }
 
 // Schema defines the provider-level schema for configuration data.
-func (p *aembitProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+func (p *aembitProvider) Schema(
+	_ context.Context,
+	_ provider.SchemaRequest,
+	resp *provider.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"tenant": schema.StringAttribute{
@@ -139,7 +159,11 @@ func (p *aembitProvider) ConfigValidators(_ context.Context) []resource.ConfigVa
 	}
 }
 
-func (p *aembitProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+func (p *aembitProvider) Configure(
+	ctx context.Context,
+	req provider.ConfigureRequest,
+	resp *provider.ConfigureResponse,
+) {
 	var err error
 	tflog.Info(ctx, "Configuring Aembit client...")
 
@@ -203,7 +227,11 @@ func (p *aembitProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	}
 	if len(aembitClientID) > 0 {
 		tenant = getAembitTenantId(aembitClientID)
-		tflog.Debug(ctx, "Using Aembit Native Authentication", map[string]interface{}{"tenantId": tenant})
+		tflog.Debug(
+			ctx,
+			"Using Aembit Native Authentication",
+			map[string]interface{}{"tenantId": tenant},
+		)
 
 		// Try with the resourceSetId first
 		if token, err = getToken(ctx, aembitClientID, stackDomain, resourceSetId, p.version); err != nil {
@@ -216,7 +244,11 @@ func (p *aembitProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		// LEGACY: This is included to authenticate to the default resource set if resource_set_id is specified in the provider
 		if token == "" {
 			if token, err = getToken(ctx, aembitClientID, stackDomain, "", p.version); err != nil {
-				tflog.Warn(ctx, "Failed to get Aembit Auth Token", map[string]interface{}{"error": err})
+				tflog.Warn(
+					ctx,
+					"Failed to get Aembit Auth Token",
+					map[string]interface{}{"error": err},
+				)
 			}
 		} else {
 			tflog.Debug(ctx, "Retrieved Aembit Auth Token for Default ResourceSet")
@@ -275,7 +307,11 @@ func (p *aembitProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	resp.DataSourceData = client
 	resp.ResourceData = client
 
-	tflog.Info(ctx, fmt.Sprintf("Configured Aembit client (%s)", p.version), map[string]any{"success": true})
+	tflog.Info(
+		ctx,
+		fmt.Sprintf("Configured Aembit client (%s)", p.version),
+		map[string]any{"success": true},
+	)
 }
 
 func (p *aembitProvider) Resources(ctx context.Context) []func() resource.Resource {
@@ -294,7 +330,7 @@ func (p *aembitProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewCredentialProviderIntegrationResource,
 		NewDiscoveryIntegrationResource,
 		NewLogStreamResource,
-		//NewResourceSetResource,	// Preventing Resource Set Resources via Terraform until we add support for deleting Resource Sets
+		// NewResourceSetResource,	// Preventing Resource Set Resources via Terraform until we add support for deleting Resource Sets
 		NewGlobalPolicyComplianceResource,
 	}
 }
@@ -324,10 +360,12 @@ func (p *aembitProvider) DataSources(ctx context.Context) []func() datasource.Da
 }
 
 // // Temporary until Aembit SDK is published.
-var GCP_ID_TOKEN string
-var GITHUB_ID_TOKEN string
-var TERRAFORM_ID_TOKEN string
-var AEMBIT_TOKEN string
+var (
+	GCP_ID_TOKEN       string
+	GITHUB_ID_TOKEN    string
+	TERRAFORM_ID_TOKEN string
+	AEMBIT_TOKEN       string
+)
 
 type ClientRequestNetwork struct {
 	TargetHost        string `json:"targetHost"`
@@ -364,7 +402,10 @@ type tokenAuth struct {
 	token string
 }
 
-func (t tokenAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
+func (t tokenAuth) GetRequestMetadata(
+	ctx context.Context,
+	in ...string,
+) (map[string]string, error) {
 	return map[string]string{
 		"authorization": "Bearer " + t.token,
 	}, nil
@@ -374,12 +415,29 @@ func (tokenAuth) RequireTransportSecurity() bool {
 	return true
 }
 
-func getToken(ctx context.Context, aembitClientID, stackDomain, resourceSetId, version string) (string, error) {
+func getToken(
+	ctx context.Context,
+	aembitClientID, stackDomain, resourceSetId, version string,
+) (string, error) {
 	idToken, err := getIdentityToken(aembitClientID, stackDomain)
 	if err == nil {
-		aembitToken, err := getAembitToken(aembitClientID, stackDomain, idToken, resourceSetId, version)
+		aembitToken, err := getAembitToken(
+			aembitClientID,
+			stackDomain,
+			idToken,
+			resourceSetId,
+			version,
+		)
 		if err == nil {
-			roleToken, err := getAembitCredential(fmt.Sprintf("%s.api.%s", getAembitTenantId(aembitClientID), stackDomain), 443, aembitClientID, stackDomain, idToken, aembitToken, resourceSetId)
+			roleToken, err := getAembitCredential(
+				fmt.Sprintf("%s.api.%s", getAembitTenantId(aembitClientID), stackDomain),
+				443,
+				aembitClientID,
+				stackDomain,
+				idToken,
+				aembitToken,
+				resourceSetId,
+			)
 			if err == nil {
 				return roleToken, nil
 			} else {
@@ -402,14 +460,20 @@ func getToken(ctx context.Context, aembitClientID, stackDomain, resourceSetId, v
 	}
 }
 
-func getAembitCredential(targetHost string, targetPort int16, clientId, stackDomain, idToken, aembitToken, resourceSetId string) (string, error) {
+func getAembitCredential(
+	targetHost string,
+	targetPort int16,
+	clientId, stackDomain, idToken, aembitToken, resourceSetId string,
+) (string, error) {
 	var err error
 	var clientRequest, workloadAssessment string
 	var conn *grpc.ClientConn
 	var aembitClient EdgeCommanderClient
 	var credResponse *CredentialResponse
 
-	tlsCreds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: false, MinVersion: tls.VersionTLS12})
+	tlsCreds := credentials.NewTLS(
+		&tls.Config{InsecureSkipVerify: false, MinVersion: tls.VersionTLS12},
+	)
 	if conn, err = grpc.NewClient(fmt.Sprintf("%s.ec.%s:443", getAembitTenantId(clientId), stackDomain), grpc.WithTransportCredentials(tlsCreds), grpc.WithPerRPCCredentials(tokenAuth{token: aembitToken})); err != nil {
 		return "", err
 	}
@@ -437,7 +501,14 @@ func getAembitCredential(targetHost string, targetPort int16, clientId, stackDom
 func getClientRequest(targetHost string, targetPort int16) (string, error) {
 	var request []byte
 	var err error
-	var clientRequest ClientRequest = ClientRequest{Version: "1.0.0", Network: ClientRequestNetwork{TargetHost: targetHost, TargetPort: targetPort, TransportProtocol: "TCP"}}
+	clientRequest := ClientRequest{
+		Version: "1.0.0",
+		Network: ClientRequestNetwork{
+			TargetHost:        targetHost,
+			TargetPort:        targetPort,
+			TransportProtocol: "TCP",
+		},
+	}
 
 	if request, err = json.Marshal(clientRequest); err != nil {
 		return "", err
@@ -452,11 +523,20 @@ func getWorkloadAssessment(clientId, idToken, resourceSetId string) (string, err
 
 	switch getAembitIdentityType(clientId) {
 	case "gcp_idtoken":
-		workload = WorkloadAssessment{Version: "1.0.0", GCP: WorkloadAssessmentIdToken{IdentityToken: idToken}}
+		workload = WorkloadAssessment{
+			Version: "1.0.0",
+			GCP:     WorkloadAssessmentIdToken{IdentityToken: idToken},
+		}
 	case "github_idtoken":
-		workload = WorkloadAssessment{Version: "1.0.0", GitHub: WorkloadAssessmentIdToken{IdentityToken: idToken}}
+		workload = WorkloadAssessment{
+			Version: "1.0.0",
+			GitHub:  WorkloadAssessmentIdToken{IdentityToken: idToken},
+		}
 	case "terraform_idtoken":
-		workload = WorkloadAssessment{Version: "1.0.0", Terraform: WorkloadAssessmentIdToken{IdentityToken: idToken}}
+		workload = WorkloadAssessment{
+			Version:   "1.0.0",
+			Terraform: WorkloadAssessmentIdToken{IdentityToken: idToken},
+		}
 	default:
 		return "", fmt.Errorf("invalid aembit client id")
 	}
@@ -509,7 +589,11 @@ func getAembitToken(clientId, stackDomain, idToken, resourceSetId, version strin
 	}
 	details.Set("attestation", string(attestationJSON))
 
-	tokenEndpoint := fmt.Sprintf("https://%s.id.%s/connect/token", getAembitTenantId(clientId), stackDomain)
+	tokenEndpoint := fmt.Sprintf(
+		"https://%s.id.%s/connect/token",
+		getAembitTenantId(clientId),
+		stackDomain,
+	)
 	req, err := http.NewRequest("POST", tokenEndpoint, bytes.NewBufferString(details.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
@@ -564,7 +648,10 @@ func getGcpIdentityToken(clientId, stackDomain string) (string, error) {
 	}
 
 	audience := fmt.Sprintf("https://%s.id.%s", getAembitTenantId(clientId), stackDomain)
-	metadataIdentityTokenUrl := fmt.Sprintf("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=%s", url.QueryEscape(audience))
+	metadataIdentityTokenUrl := fmt.Sprintf(
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=%s",
+		url.QueryEscape(audience),
+	)
 
 	req, err := http.NewRequest("GET", metadataIdentityTokenUrl, nil)
 	if err != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	testClient *aembit.CloudClient
-)
+var testClient *aembit.CloudClient
 
 func init() {
 	tenant := os.Getenv("AEMBIT_TENANT_ID")
@@ -44,7 +42,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 func TestUnitResourceConfigure(t *testing.T) {
-	var configResponse resource.ConfigureResponse = resource.ConfigureResponse{}
+	configResponse := resource.ConfigureResponse{}
 	resourceConfigure(resource.ConfigureRequest{ProviderData: nil}, &configResponse)
 	assert.Empty(t, configResponse.Diagnostics)
 
@@ -53,7 +51,7 @@ func TestUnitResourceConfigure(t *testing.T) {
 }
 
 func TestUnitDataSourceConfigure(t *testing.T) {
-	var configResponse datasource.ConfigureResponse = datasource.ConfigureResponse{}
+	configResponse := datasource.ConfigureResponse{}
 	datasourceConfigure(datasource.ConfigureRequest{ProviderData: nil}, &configResponse)
 	assert.Empty(t, configResponse.Diagnostics)
 

--- a/internal/provider/resource_set_data_source.go
+++ b/internal/provider/resource_set_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -29,17 +29,29 @@ type resourceSetDataSource struct {
 // Implementations for resourceSetDataSource (singular)
 
 // Configure adds the provider configured client to the data source.
-func (d *resourceSetDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *resourceSetDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *resourceSetDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *resourceSetDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_resource_set"
 }
 
 // Schema defines the schema for the resource.
-func (d *resourceSetDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *resourceSetDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Use this data source to get information about an Aembit ResourceSet.",
 		Attributes: map[string]schema.Attribute{
@@ -71,7 +83,11 @@ func (d *resourceSetDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 }
 
 // Read checks for the datasource ID and retrieves the associated ResourceSet.
-func (d *resourceSetDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *resourceSetDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.ResourceSetResourceModel
 	diags := req.Config.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_set_data_source_test.go
+++ b/internal/provider/resource_set_data_source_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-const testResourceSetDefault string = "data.aembit_resource_set.default"
-const testResourceSetsAll string = "data.aembit_resource_sets.all"
+const (
+	testResourceSetDefault string = "data.aembit_resource_set.default"
+	testResourceSetsAll    string = "data.aembit_resource_sets.all"
+)
 
 func TestAccDefaultResourceSet(t *testing.T) {
 	readFile, _ := os.ReadFile("../../tests/resource_set/TestAccDefaultResourceSet.tf")
@@ -22,9 +24,17 @@ func TestAccDefaultResourceSet(t *testing.T) {
 				Config: string(readFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceSetDefault, "name", "Default"),
-					resource.TestCheckResourceAttr(testResourceSetDefault, "id", "ffffffff-ffff-ffff-ffff-ffffffffffff"),
+					resource.TestCheckResourceAttr(
+						testResourceSetDefault,
+						"id",
+						"ffffffff-ffff-ffff-ffff-ffffffffffff",
+					),
 
-					resource.TestMatchResourceAttr(testResourceSetsAll, "resource_sets.#", regexp.MustCompile(`[2-9]`)),
+					resource.TestMatchResourceAttr(
+						testResourceSetsAll,
+						"resource_sets.#",
+						regexp.MustCompile(`[2-9]`),
+					),
 				),
 			},
 		},

--- a/internal/provider/resource_set_resource.go
+++ b/internal/provider/resource_set_resource.go
@@ -100,7 +100,7 @@ func (r *resourceSetResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Generate API request body from plan
-	var trust aembit.ResourceSetDTO = convertResourceSetModelToDTO(ctx, plan, nil)
+	var trust = convertResourceSetModelToDTO(ctx, plan, nil)
 
 	// Create new ResourceSet
 	role, err := r.client.CreateResourceSet(trust, nil)

--- a/internal/provider/resource_set_resource.go
+++ b/internal/provider/resource_set_resource.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -14,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -34,17 +34,29 @@ type resourceSetResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *resourceSetResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *resourceSetResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_resource_set"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *resourceSetResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *resourceSetResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *resourceSetResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *resourceSetResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -75,7 +87,9 @@ func (r *resourceSetResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(validators.UUIDRegexValidation()),
 				},
-				Default: setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
+				Default: setdefault.StaticValue(
+					types.SetValueMust(types.StringType, []attr.Value{}),
+				),
 			},
 			"standalone_certificate_authority": schema.StringAttribute{
 				Description: "Standalone Certificate Authority ID configured for this ResourceSet.",
@@ -90,7 +104,11 @@ func (r *resourceSetResource) Schema(_ context.Context, _ resource.SchemaRequest
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *resourceSetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *resourceSetResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.ResourceSetResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -100,7 +118,7 @@ func (r *resourceSetResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Generate API request body from plan
-	var trust = convertResourceSetModelToDTO(ctx, plan, nil)
+	trust := convertResourceSetModelToDTO(ctx, plan, nil)
 
 	// Create new ResourceSet
 	role, err := r.client.CreateResourceSet(trust, nil)
@@ -124,7 +142,11 @@ func (r *resourceSetResource) Create(ctx context.Context, req resource.CreateReq
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *resourceSetResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *resourceSetResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.ResourceSetResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -159,7 +181,11 @@ func (r *resourceSetResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *resourceSetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *resourceSetResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.ResourceSetResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -180,7 +206,7 @@ func (r *resourceSetResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	// Generate API request body from plan
-	var trust aembit.ResourceSetDTO = convertResourceSetModelToDTO(ctx, plan, &externalID)
+	trust := convertResourceSetModelToDTO(ctx, plan, &externalID)
 
 	// Update ResourceSet
 	role, err := r.client.UpdateResourceSet(trust, nil)
@@ -204,7 +230,11 @@ func (r *resourceSetResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *resourceSetResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *resourceSetResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.ResourceSetResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -225,13 +255,21 @@ func (r *resourceSetResource) Delete(ctx context.Context, req resource.DeleteReq
 }
 
 // Imports an existing resource by passing externalId.
-func (r *resourceSetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *resourceSetResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // Model to DTO conversion methods.
-func convertResourceSetModelToDTO(_ context.Context, model models.ResourceSetResourceModel, externalID *string) aembit.ResourceSetDTO {
+func convertResourceSetModelToDTO(
+	_ context.Context,
+	model models.ResourceSetResourceModel,
+	externalID *string,
+) aembit.ResourceSetDTO {
 	var dto aembit.ResourceSetDTO
 	dto.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -239,7 +277,7 @@ func convertResourceSetModelToDTO(_ context.Context, model models.ResourceSetRes
 		IsActive:    true,
 	}
 	if externalID != nil {
-		dto.EntityDTO.ExternalID = *externalID
+		dto.ExternalID = *externalID
 	}
 
 	dto.Roles = make([]string, len(model.Roles))
@@ -259,11 +297,14 @@ func convertResourceSetModelToDTO(_ context.Context, model models.ResourceSetRes
 }
 
 // DTO to Model conversion methods.
-func convertResourceSetDTOToModel(_ context.Context, dto aembit.ResourceSetDTO) models.ResourceSetResourceModel {
+func convertResourceSetDTOToModel(
+	_ context.Context,
+	dto aembit.ResourceSetDTO,
+) models.ResourceSetResourceModel {
 	var model models.ResourceSetResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
 	model.StandaloneCertificateAuthority = types.StringValue(dto.StandaloneCertificateAuthority)
 
 	model.Roles = make([]types.String, len(dto.Roles))

--- a/internal/provider/resource_sets_data_source.go
+++ b/internal/provider/resource_sets_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type resourceSetsDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *resourceSetsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *resourceSetsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *resourceSetsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *resourceSetsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_resource_sets"
 }
 
 // Schema defines the schema for the resource.
-func (d *resourceSetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *resourceSetsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Use this data source to get information about all Aembit ResourceSets.",
 		Attributes: map[string]schema.Attribute{
@@ -76,7 +88,11 @@ func (d *resourceSetsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 }
 
 // Read checks for the datasource ID and retrieves the associated ResourceSet.
-func (d *resourceSetsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *resourceSetsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.ResourceSetsDataModel
 	diags := req.Config.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -105,15 +121,18 @@ func (d *resourceSetsDataSource) Read(ctx context.Context, req datasource.ReadRe
 }
 
 // DTO to Model conversion methods.
-func convertResourceSetsDTOToModel(_ context.Context, dto []aembit.ResourceSetDTO) models.ResourceSetsDataModel {
-	var model models.ResourceSetsDataModel = models.ResourceSetsDataModel{
+func convertResourceSetsDTOToModel(
+	_ context.Context,
+	dto []aembit.ResourceSetDTO,
+) models.ResourceSetsDataModel {
+	model := models.ResourceSetsDataModel{
 		ResourceSets: make([]models.ResourceSetResourceModel, len(dto)),
 	}
 	for index, resourceSet := range dto {
 		model.ResourceSets[index] = models.ResourceSetResourceModel{
-			ID:          types.StringValue(resourceSet.EntityDTO.ExternalID),
-			Name:        types.StringValue(resourceSet.EntityDTO.Name),
-			Description: types.StringValue(resourceSet.EntityDTO.Description),
+			ID:          types.StringValue(resourceSet.ExternalID),
+			Name:        types.StringValue(resourceSet.Name),
+			Description: types.StringValue(resourceSet.Description),
 			Roles:       make([]types.String, len(resourceSet.Roles)),
 		}
 		model.ResourceSets[index].Roles = make([]types.String, len(resourceSet.Roles))

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -366,11 +366,11 @@ func appendReadOnlyPermissionToDTO(list []aembit.RolePermissionDTO, name string,
 // DTO to Model conversion methods.
 func convertRoleDTOToModel(ctx context.Context, dto aembit.RoleDTO) models.RoleResourceModel {
 	var model models.RoleResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 
 	for _, permission := range dto.Permissions {
 		switch permission.Name {

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -3,8 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -12,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -39,17 +39,29 @@ type roleResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *roleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *roleResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_role"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *roleResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *roleResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *roleResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -82,25 +94,64 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				ElementType: types.StringType,
 				Optional:    true,
 			},
-			"access_policies":                    definePermissionAttribute("Access Policy", false),
-			"client_workloads":                   definePermissionAttribute("Client Workload", false),
-			"trust_providers":                    definePermissionAttribute("Trust Provider", false),
-			"access_conditions":                  definePermissionAttribute("Access Condition", false),
-			"integrations":                       definePermissionAttribute("Integration", false),
-			"credential_providers":               definePermissionAttribute("Credential Provider", false),
-			"server_workloads":                   definePermissionAttribute("Server Workload", false),
-			"agent_controllers":                  definePermissionAttribute("Agent Controller", false),
-			"standalone_certificate_authorities": definePermissionAttribute("Standalone Certificate Authority", false),
-			"access_authorization_events":        definePermissionReadOnlyAttribute("Access Authorization Event", false),
-			"audit_logs":                         definePermissionReadOnlyAttribute("Audit Log", false),
-			"workload_events":                    definePermissionReadOnlyAttribute("Workload Event", false),
-			"users":                              definePermissionAttribute("User", false),
-			"roles":                              definePermissionAttribute("Role", false),
-			"log_streams":                        definePermissionAttribute("Log Stream", false),
-			"identity_providers":                 definePermissionAttribute("Identity Provider", false),
-			"signon_policy":                      definePermissionAttribute(SignOnPolicyPermissionName, false),
-			"resource_sets":                      definePermissionAttribute("Resource Set", false),
-			"routing":                            definePermissionAttribute(RoutingPermissiongName, false),
+			"access_policies": definePermissionAttribute("Access Policy", false),
+			"client_workloads": definePermissionAttribute(
+				"Client Workload",
+				false,
+			),
+			"trust_providers": definePermissionAttribute(
+				"Trust Provider",
+				false,
+			),
+			"access_conditions": definePermissionAttribute(
+				"Access Condition",
+				false,
+			),
+			"integrations": definePermissionAttribute("Integration", false),
+			"credential_providers": definePermissionAttribute(
+				"Credential Provider",
+				false,
+			),
+			"server_workloads": definePermissionAttribute(
+				"Server Workload",
+				false,
+			),
+			"agent_controllers": definePermissionAttribute(
+				"Agent Controller",
+				false,
+			),
+			"standalone_certificate_authorities": definePermissionAttribute(
+				"Standalone Certificate Authority",
+				false,
+			),
+			"access_authorization_events": definePermissionReadOnlyAttribute(
+				"Access Authorization Event",
+				false,
+			),
+			"audit_logs": definePermissionReadOnlyAttribute(
+				"Audit Log",
+				false,
+			),
+			"workload_events": definePermissionReadOnlyAttribute(
+				"Workload Event",
+				false,
+			),
+			"users":       definePermissionAttribute("User", false),
+			"roles":       definePermissionAttribute("Role", false),
+			"log_streams": definePermissionAttribute("Log Stream", false),
+			"identity_providers": definePermissionAttribute(
+				"Identity Provider",
+				false,
+			),
+			"signon_policy": definePermissionAttribute(
+				SignOnPolicyPermissionName,
+				false,
+			),
+			"resource_sets": definePermissionAttribute("Resource Set", false),
+			"routing": definePermissionAttribute(
+				RoutingPermissiongName,
+				false,
+			),
 		},
 	}
 }
@@ -111,14 +162,20 @@ func definePermissionAttribute(name string, computed bool) schema.SingleNestedAt
 		Required:    true,
 		Attributes: map[string]schema.Attribute{
 			"read": schema.BoolAttribute{
-				Description: fmt.Sprintf("True if this Role should be able to query and view %s resources.", name),
-				Required:    !computed,
-				Computed:    computed,
+				Description: fmt.Sprintf(
+					"True if this Role should be able to query and view %s resources.",
+					name,
+				),
+				Required: !computed,
+				Computed: computed,
 			},
 			"write": schema.BoolAttribute{
-				Description: fmt.Sprintf("True if this Role should be able to create and update %s resources.", name),
-				Required:    !computed,
-				Computed:    computed,
+				Description: fmt.Sprintf(
+					"True if this Role should be able to create and update %s resources.",
+					name,
+				),
+				Required: !computed,
+				Computed: computed,
 			},
 		},
 	}
@@ -130,16 +187,23 @@ func definePermissionReadOnlyAttribute(name string, computed bool) schema.Single
 		Required:    true,
 		Attributes: map[string]schema.Attribute{
 			"read": schema.BoolAttribute{
-				Description: fmt.Sprintf("True if this Role should be able to query and view %s data.", name),
-				Required:    !computed,
-				Computed:    computed,
+				Description: fmt.Sprintf(
+					"True if this Role should be able to query and view %s data.",
+					name,
+				),
+				Required: !computed,
+				Computed: computed,
 			},
 		},
 	}
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *roleResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.RoleResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -149,7 +213,7 @@ func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Generate API request body from plan
-	var trust aembit.RoleDTO = convertRoleModelToDTO(ctx, plan, nil)
+	trust := convertRoleModelToDTO(ctx, plan, nil)
 
 	// Create new Role
 	role, err := r.client.CreateRole(trust, nil)
@@ -173,7 +237,11 @@ func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, r
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *roleResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.RoleResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -208,7 +276,11 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *roleResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.RoleResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -229,7 +301,7 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Generate API request body from plan
-	var trust aembit.RoleDTO = convertRoleModelToDTO(ctx, plan, &externalID)
+	trust := convertRoleModelToDTO(ctx, plan, &externalID)
 
 	// Update Role
 	role, err := r.client.UpdateRole(trust, nil)
@@ -253,7 +325,11 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *roleResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.RoleResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -286,13 +362,21 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 }
 
 // Imports an existing resource by passing externalId.
-func (r *roleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *roleResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // Model to DTO conversion methods.
-func convertRoleModelToDTO(ctx context.Context, model models.RoleResourceModel, externalID *string) aembit.RoleDTO {
+func convertRoleModelToDTO(
+	ctx context.Context,
+	model models.RoleResourceModel,
+	externalID *string,
+) aembit.RoleDTO {
 	var dto aembit.RoleDTO
 	dto.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -311,38 +395,94 @@ func convertRoleModelToDTO(ctx context.Context, model models.RoleResourceModel, 
 		}
 	}
 	if externalID != nil {
-		dto.EntityDTO.ExternalID = *externalID
+		dto.ExternalID = *externalID
 	}
 
 	dto.Permissions = make([]aembit.RolePermissionDTO, 0)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Access Policies", model.AccessPolicies)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Access Policies",
+		model.AccessPolicies,
+	)
 	dto.Permissions = appendPermissionToDTO(dto.Permissions, RoutingPermissiongName, model.Routing)
 
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Client Workloads", model.AccessPolicies)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Trust Providers", model.ClientWorkloads)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Access Conditions", model.AccessConditions)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Client Workloads",
+		model.AccessPolicies,
+	)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Trust Providers",
+		model.ClientWorkloads,
+	)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Access Conditions",
+		model.AccessConditions,
+	)
 	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Integrations", model.Integrations)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Credential Providers", model.CredentialProviders)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Server Workloads", model.ServerWorkloads)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Credential Providers",
+		model.CredentialProviders,
+	)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Server Workloads",
+		model.ServerWorkloads,
+	)
 
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Agent Controllers", model.AgentControllers)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, StandaloneCertificateAuthoritiesPermissionName, model.StandaloneCertificateAuthorities)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Agent Controllers",
+		model.AgentControllers,
+	)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		StandaloneCertificateAuthoritiesPermissionName,
+		model.StandaloneCertificateAuthorities,
+	)
 
-	dto.Permissions = appendReadOnlyPermissionToDTO(dto.Permissions, "Access Authorization Events", model.AccessAuthorizationEvents)
+	dto.Permissions = appendReadOnlyPermissionToDTO(
+		dto.Permissions,
+		"Access Authorization Events",
+		model.AccessAuthorizationEvents,
+	)
 	dto.Permissions = appendReadOnlyPermissionToDTO(dto.Permissions, "Audit Logs", model.AuditLogs)
-	dto.Permissions = appendReadOnlyPermissionToDTO(dto.Permissions, "Workload Events", model.WorkloadEvents)
+	dto.Permissions = appendReadOnlyPermissionToDTO(
+		dto.Permissions,
+		"Workload Events",
+		model.WorkloadEvents,
+	)
 
 	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Users", model.Users)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, SignOnPolicyPermissionName, model.SignOnPolicy)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		SignOnPolicyPermissionName,
+		model.SignOnPolicy,
+	)
 	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Roles", model.Roles)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, ResourceSetsPermissionName, model.ResourceSets)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		ResourceSetsPermissionName,
+		model.ResourceSets,
+	)
 	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Log Streams", model.LogStreams)
-	dto.Permissions = appendPermissionToDTO(dto.Permissions, "Identity Providers", model.IdentityProviders)
+	dto.Permissions = appendPermissionToDTO(
+		dto.Permissions,
+		"Identity Providers",
+		model.IdentityProviders,
+	)
 
 	return dto
 }
 
-func appendPermissionToDTO(list []aembit.RolePermissionDTO, name string, permission *models.RolePermission) []aembit.RolePermissionDTO {
+func appendPermissionToDTO(
+	list []aembit.RolePermissionDTO,
+	name string,
+	permission *models.RolePermission,
+) []aembit.RolePermissionDTO {
 	if permission == nil {
 		return list
 	}
@@ -353,7 +493,11 @@ func appendPermissionToDTO(list []aembit.RolePermissionDTO, name string, permiss
 	})
 }
 
-func appendReadOnlyPermissionToDTO(list []aembit.RolePermissionDTO, name string, permission *models.RoleReadOnlyPermission) []aembit.RolePermissionDTO {
+func appendReadOnlyPermissionToDTO(
+	list []aembit.RolePermissionDTO,
+	name string,
+	permission *models.RoleReadOnlyPermission,
+) []aembit.RolePermissionDTO {
 	if permission == nil {
 		return list
 	}
@@ -425,7 +569,9 @@ func convertPermissionDTOToPermission(permission aembit.RolePermissionDTO) *mode
 	}
 }
 
-func convertPermissionDTOToReadOnlyPermission(permission aembit.RolePermissionDTO) *models.RoleReadOnlyPermission {
+func convertPermissionDTOToReadOnlyPermission(
+	permission aembit.RolePermissionDTO,
+) *models.RoleReadOnlyPermission {
 	return &models.RoleReadOnlyPermission{
 		Read: types.BoolValue(permission.Read),
 	}

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -30,7 +30,11 @@ func testDeleteRole(resourceName string) resource.TestCheckFunc {
 func TestAccRoleResource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/roles/TestAccRoleResource.tf")
 	modifyFile, _ := os.ReadFile("../../tests/roles/TestAccRoleResource.tfmod")
-	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(string(createFile), string(modifyFile), "TF Acceptance Role")
+	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"TF Acceptance Role",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/roles_data_source.go
+++ b/internal/provider/roles_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type rolesDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *rolesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *rolesDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *rolesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *rolesDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_roles"
 }
 
 // Schema defines the schema for the resource.
-func (d *rolesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *rolesDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages an role.",
 		Attributes: map[string]schema.Attribute{
@@ -67,25 +79,82 @@ func (d *rolesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 							ElementType: types.StringType,
 							Computed:    true,
 						},
-						"access_policies":                    definePermissionAttribute("Access Policy", true),
-						"client_workloads":                   definePermissionAttribute("Client Workload", true),
-						"trust_providers":                    definePermissionAttribute("Trust Provider", true),
-						"access_conditions":                  definePermissionAttribute("Access Condition", true),
-						"integrations":                       definePermissionAttribute("Integration", true),
-						"credential_providers":               definePermissionAttribute("Credential Provider", true),
-						"server_workloads":                   definePermissionAttribute("Server Workload", true),
-						"agent_controllers":                  definePermissionAttribute("Agent Controller", true),
-						"standalone_certificate_authorities": definePermissionAttribute(StandaloneCertificateAuthoritiesPermissionName, true),
-						"access_authorization_events":        definePermissionReadOnlyAttribute("Access Authorization Event", true),
-						"audit_logs":                         definePermissionReadOnlyAttribute("Audit Log", true),
-						"workload_events":                    definePermissionReadOnlyAttribute("Workload Event", true),
-						"users":                              definePermissionAttribute("User", true),
-						"roles":                              definePermissionAttribute("Role", true),
-						"log_streams":                        definePermissionAttribute("Log Stream", true),
-						"identity_providers":                 definePermissionAttribute("Identity Provider", true),
-						"signon_policy":                      definePermissionAttribute(SignOnPolicyPermissionName, true),
-						"routing":                            definePermissionAttribute(RoutingPermissiongName, true),
-						"resource_sets":                      definePermissionAttribute(ResourceSetsPermissionName, true),
+						"access_policies": definePermissionAttribute(
+							"Access Policy",
+							true,
+						),
+						"client_workloads": definePermissionAttribute(
+							"Client Workload",
+							true,
+						),
+						"trust_providers": definePermissionAttribute(
+							"Trust Provider",
+							true,
+						),
+						"access_conditions": definePermissionAttribute(
+							"Access Condition",
+							true,
+						),
+						"integrations": definePermissionAttribute(
+							"Integration",
+							true,
+						),
+						"credential_providers": definePermissionAttribute(
+							"Credential Provider",
+							true,
+						),
+						"server_workloads": definePermissionAttribute(
+							"Server Workload",
+							true,
+						),
+						"agent_controllers": definePermissionAttribute(
+							"Agent Controller",
+							true,
+						),
+						"standalone_certificate_authorities": definePermissionAttribute(
+							StandaloneCertificateAuthoritiesPermissionName,
+							true,
+						),
+						"access_authorization_events": definePermissionReadOnlyAttribute(
+							"Access Authorization Event",
+							true,
+						),
+						"audit_logs": definePermissionReadOnlyAttribute(
+							"Audit Log",
+							true,
+						),
+						"workload_events": definePermissionReadOnlyAttribute(
+							"Workload Event",
+							true,
+						),
+						"users": definePermissionAttribute(
+							"User",
+							true,
+						),
+						"roles": definePermissionAttribute(
+							"Role",
+							true,
+						),
+						"log_streams": definePermissionAttribute(
+							"Log Stream",
+							true,
+						),
+						"identity_providers": definePermissionAttribute(
+							"Identity Provider",
+							true,
+						),
+						"signon_policy": definePermissionAttribute(
+							SignOnPolicyPermissionName,
+							true,
+						),
+						"routing": definePermissionAttribute(
+							RoutingPermissiongName,
+							true,
+						),
+						"resource_sets": definePermissionAttribute(
+							ResourceSetsPermissionName,
+							true,
+						),
 					},
 				},
 			},
@@ -94,7 +163,11 @@ func (d *rolesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *rolesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *rolesDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.RolesDataSourceModel
 
 	roles, err := d.client.GetRoles(nil)

--- a/internal/provider/roles_data_source_test.go
+++ b/internal/provider/roles_data_source_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testRolesDataSource string = "data.aembit_roles.test"
-const testRoleResource string = "aembit_role.role"
+const (
+	testRolesDataSource string = "data.aembit_roles.test"
+	testRoleResource    string = "aembit_role.role"
+)
 
 func testFindRole(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -31,10 +33,13 @@ func testFindRole(resourceName string) resource.TestCheckFunc {
 }
 
 func TestAccRolesDataSource(t *testing.T) {
-
 	createFile, _ := os.ReadFile("../../tests/roles/data/TestAccRolesDataSource.tf")
 	randID := rand.Intn(10000000)
-	createFileConfig := strings.ReplaceAll(string(createFile), "TF Acceptance Role", fmt.Sprintf("TF Acceptance Role%d", randID))
+	createFileConfig := strings.ReplaceAll(
+		string(createFile),
+		"TF Acceptance Role",
+		fmt.Sprintf("TF Acceptance Role%d", randID),
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -46,10 +51,22 @@ func TestAccRolesDataSource(t *testing.T) {
 					// Verify number of Roles returned
 					resource.TestCheckResourceAttrSet(testRolesDataSource, "roles.#"),
 					// Verify the attributes of the first three roles
-					resource.TestCheckResourceAttr(testRolesDataSource, "roles.0.name", "SuperAdmin"),
-					resource.TestCheckResourceAttr(testRolesDataSource, "roles.0.is_active", "true"),
+					resource.TestCheckResourceAttr(
+						testRolesDataSource,
+						"roles.0.name",
+						"SuperAdmin",
+					),
+					resource.TestCheckResourceAttr(
+						testRolesDataSource,
+						"roles.0.is_active",
+						"true",
+					),
 					resource.TestCheckResourceAttr(testRolesDataSource, "roles.1.name", "Auditor"),
-					resource.TestCheckResourceAttr(testRolesDataSource, "roles.1.is_active", "true"),
+					resource.TestCheckResourceAttr(
+						testRolesDataSource,
+						"roles.1.is_active",
+						"true",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testRolesDataSource, "roles.0.id"),
 					resource.TestCheckResourceAttrSet(testRolesDataSource, "roles.1.id"),

--- a/internal/provider/server_workload_resource.go
+++ b/internal/provider/server_workload_resource.go
@@ -92,7 +92,7 @@ func (r *serverWorkloadResource) Schema(_ context.Context, _ resource.SchemaRequ
 						Description: "Hostname of the Server Workload service endpoint.",
 						Required:    true,
 						Validators: []validator.String{
-							validators.HostValidation(),
+							validators.SafeWildcardHostNameValidation(),
 						},
 					},
 					"port": schema.Int64Attribute{
@@ -430,7 +430,7 @@ func convertServerWorkloadModelToDTO(ctx context.Context, model models.ServerWor
 	}
 
 	if externalID != nil {
-		workload.EntityDTO.ExternalID = *externalID
+		workload.ExternalID = *externalID
 	}
 
 	return workload
@@ -438,11 +438,11 @@ func convertServerWorkloadModelToDTO(ctx context.Context, model models.ServerWor
 
 func convertServerWorkloadDTOToModel(ctx context.Context, dto aembit.ServerWorkloadExternalDTO) models.ServerWorkloadResourceModel {
 	var model models.ServerWorkloadResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 
 	model.ServiceEndpoint = &models.ServiceEndpointModel{
 		ExternalID:        types.StringValue(dto.ServiceEndpoint.ExternalID),

--- a/internal/provider/server_workload_resource.go
+++ b/internal/provider/server_workload_resource.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -13,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -33,17 +33,29 @@ type serverWorkloadResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *serverWorkloadResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *serverWorkloadResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_server_workload"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *serverWorkloadResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *serverWorkloadResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *serverWorkloadResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *serverWorkloadResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -225,7 +237,11 @@ func (r *serverWorkloadResource) Schema(_ context.Context, _ resource.SchemaRequ
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *serverWorkloadResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *serverWorkloadResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.ServerWorkloadResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -235,7 +251,7 @@ func (r *serverWorkloadResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Generate API request body from plan
-	var workload aembit.ServerWorkloadExternalDTO = convertServerWorkloadModelToDTO(ctx, plan, nil)
+	workload := convertServerWorkloadModelToDTO(ctx, plan, nil)
 
 	// Create new Server Workload
 	serverWorkload, err := r.client.CreateServerWorkload(workload, nil)
@@ -259,7 +275,11 @@ func (r *serverWorkloadResource) Create(ctx context.Context, req resource.Create
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *serverWorkloadResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *serverWorkloadResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.ServerWorkloadResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -295,7 +315,11 @@ func (r *serverWorkloadResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *serverWorkloadResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *serverWorkloadResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.ServerWorkloadResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -305,7 +329,7 @@ func (r *serverWorkloadResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Extract external ID from state
-	var externalID string = state.ID.ValueString()
+	externalID := state.ID.ValueString()
 
 	// Retrieve values from plan
 	var plan models.ServerWorkloadResourceModel
@@ -316,7 +340,7 @@ func (r *serverWorkloadResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Generate API request body from plan
-	var workload aembit.ServerWorkloadExternalDTO = convertServerWorkloadModelToDTO(ctx, plan, &externalID)
+	workload := convertServerWorkloadModelToDTO(ctx, plan, &externalID)
 
 	// Update Server Workload
 	serverWorkload, err := r.client.UpdateServerWorkload(workload, nil)
@@ -340,7 +364,11 @@ func (r *serverWorkloadResource) Update(ctx context.Context, req resource.Update
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *serverWorkloadResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *serverWorkloadResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.ServerWorkloadResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -373,12 +401,20 @@ func (r *serverWorkloadResource) Delete(ctx context.Context, req resource.Delete
 }
 
 // Imports an existing resource by passing externalID.
-func (r *serverWorkloadResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *serverWorkloadResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalID and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertServerWorkloadModelToDTO(ctx context.Context, model models.ServerWorkloadResourceModel, externalID *string) aembit.ServerWorkloadExternalDTO {
+func convertServerWorkloadModelToDTO(
+	ctx context.Context,
+	model models.ServerWorkloadResourceModel,
+	externalID *string,
+) aembit.ServerWorkloadExternalDTO {
 	var workload aembit.ServerWorkloadExternalDTO
 	workload.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -422,10 +458,13 @@ func convertServerWorkloadModelToDTO(ctx context.Context, model models.ServerWor
 		_ = model.ServiceEndpoint.HTTPHeaders.ElementsAs(ctx, &headersMap, true)
 
 		for key, value := range headersMap {
-			workload.ServiceEndpoint.HTTPHeaders = append(workload.ServiceEndpoint.HTTPHeaders, aembit.KeyValuePair{
-				Key:   key,
-				Value: value,
-			})
+			workload.ServiceEndpoint.HTTPHeaders = append(
+				workload.ServiceEndpoint.HTTPHeaders,
+				aembit.KeyValuePair{
+					Key:   key,
+					Value: value,
+				},
+			)
 		}
 	}
 
@@ -436,7 +475,10 @@ func convertServerWorkloadModelToDTO(ctx context.Context, model models.ServerWor
 	return workload
 }
 
-func convertServerWorkloadDTOToModel(ctx context.Context, dto aembit.ServerWorkloadExternalDTO) models.ServerWorkloadResourceModel {
+func convertServerWorkloadDTOToModel(
+	ctx context.Context,
+	dto aembit.ServerWorkloadExternalDTO,
+) models.ServerWorkloadResourceModel {
 	var model models.ServerWorkloadResourceModel
 	model.ID = types.StringValue(dto.ExternalID)
 	model.Name = types.StringValue(dto.Name)

--- a/internal/provider/server_workload_resource_test.go
+++ b/internal/provider/server_workload_resource_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 const testServerWorkloadResource string = "aembit_server_workload.test"
+const testServerWorkloadResourceWildcard string = "aembit_server_workload.test_wildcard"
 
 func testDeleteServerWorkload(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -47,6 +48,7 @@ func TestAccServerWorkloadResource(t *testing.T) {
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsDay, "Sunday"),
 					// Verify Service Endpoint.
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.host", "unittest.testhost.com"),
+					resource.TestCheckResourceAttr(testServerWorkloadResourceWildcard, "service_endpoint.host", "*.testhost.com"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.port", "443"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.app_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.transport_protocol", "TCP"),
@@ -85,6 +87,7 @@ func TestAccServerWorkloadResource(t *testing.T) {
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsDay, "Tuesday"),
 					// Verify Service Endpoint updated.
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.host", "unittest.testhost2.com"),
+					resource.TestCheckResourceAttr(testServerWorkloadResourceWildcard, "service_endpoint.host", "*.testhost2.com"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.method", "HTTP Authentication"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.scheme", "Header"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.config", "X-Vault-Token"),

--- a/internal/provider/server_workload_resource_test.go
+++ b/internal/provider/server_workload_resource_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testServerWorkloadResource string = "aembit_server_workload.test"
-const testServerWorkloadResourceWildcard string = "aembit_server_workload.test_wildcard"
+const (
+	testServerWorkloadResource         string = "aembit_server_workload.test"
+	testServerWorkloadResourceWildcard string = "aembit_server_workload.test_wildcard"
+	serverWorkloadEndpointHost         string = "service_endpoint.host"
+)
 
 func testDeleteServerWorkload(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -40,36 +43,103 @@ func TestAccServerWorkloadResource(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Server Workload Name
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "name", "Unit Test 1"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "is_active", "false"),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"name",
+						"Unit Test 1",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"is_active",
+						"false",
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsColor, "blue"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsDay, "Sunday"),
 					// Verify Service Endpoint.
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.host", "unittest.testhost.com"),
-					resource.TestCheckResourceAttr(testServerWorkloadResourceWildcard, "service_endpoint.host", "*.testhost.com"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.port", "443"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.app_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.transport_protocol", "TCP"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.requested_port", "443"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.tls_verification", "full"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.method", "HTTP Authentication"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.scheme", "Bearer"),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						serverWorkloadEndpointHost,
+						"unittest.testhost.com",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResourceWildcard,
+						"service_endpoint.host",
+						"*.testhost.com",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.port",
+						"443",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.app_protocol",
+						"HTTP",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.transport_protocol",
+						"TCP",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.requested_port",
+						"443",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.tls_verification",
+						"full",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.authentication_config.method",
+						"HTTP Authentication",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.authentication_config.scheme",
+						"Bearer",
+					),
 					// Verify HTTP Headers.
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.http_headers.%", "3"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.http_headers.host", "graph.microsoft.com"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.http_headers.user-agent", "curl/7.64.1"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.http_headers.accept", "*/*"),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.http_headers.%",
+						"3",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.http_headers.host",
+						"graph.microsoft.com",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.http_headers.user-agent",
+						"curl/7.64.1",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.http_headers.accept",
+						"*/*",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(testServerWorkloadResource, "id"),
-					resource.TestCheckResourceAttrSet(testServerWorkloadResource, "service_endpoint.external_id"),
+					resource.TestCheckResourceAttrSet(
+						testServerWorkloadResource,
+						"service_endpoint.external_id",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(testServerWorkloadResource, "id"),
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteServerWorkload(testServerWorkloadResource), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteServerWorkload(testServerWorkloadResource),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
@@ -79,20 +149,48 @@ func TestAccServerWorkloadResource(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "name", "Unit Test 1 - Modified"),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"name",
+						"Unit Test 1 - Modified",
+					),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, "is_active", "true"),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsCount, "2"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsColor, "orange"),
 					resource.TestCheckResourceAttr(testServerWorkloadResource, tagsDay, "Tuesday"),
 					// Verify Service Endpoint updated.
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.host", "unittest.testhost2.com"),
-					resource.TestCheckResourceAttr(testServerWorkloadResourceWildcard, "service_endpoint.host", "*.testhost2.com"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.method", "HTTP Authentication"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.scheme", "Header"),
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.authentication_config.config", "X-Vault-Token"),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.host",
+						"unittest.testhost2.com",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResourceWildcard,
+						"service_endpoint.host",
+						"*.testhost2.com",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.authentication_config.method",
+						"HTTP Authentication",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.authentication_config.scheme",
+						"Header",
+					),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.authentication_config.config",
+						"X-Vault-Token",
+					),
 					// Verify HTTP Headers.
-					resource.TestCheckResourceAttr(testServerWorkloadResource, "service_endpoint.http_headers.%", "0"),
+					resource.TestCheckResourceAttr(
+						testServerWorkloadResource,
+						"service_endpoint.http_headers.%",
+						"0",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/server_workload_resource_test.go
+++ b/internal/provider/server_workload_resource_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	testServerWorkloadResource         string = "aembit_server_workload.test"
-	testServerWorkloadResourceWildcard string = "aembit_server_workload.test_wildcard"
-	serverWorkloadEndpointHost         string = "service_endpoint.host"
+	testServerWorkloadResource         = "aembit_server_workload.test"
+	testServerWorkloadResourceWildcard = "aembit_server_workload.test_wildcard"
+	serverWorkloadEndpointHost         = "service_endpoint.host"
 )
 
 func testDeleteServerWorkload(resourceName string) resource.TestCheckFunc {
@@ -65,7 +65,7 @@ func TestAccServerWorkloadResource(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						testServerWorkloadResourceWildcard,
-						"service_endpoint.host",
+						serverWorkloadEndpointHost,
 						"*.testhost.com",
 					),
 					resource.TestCheckResourceAttr(
@@ -162,12 +162,12 @@ func TestAccServerWorkloadResource(t *testing.T) {
 					// Verify Service Endpoint updated.
 					resource.TestCheckResourceAttr(
 						testServerWorkloadResource,
-						"service_endpoint.host",
+						serverWorkloadEndpointHost,
 						"unittest.testhost2.com",
 					),
 					resource.TestCheckResourceAttr(
 						testServerWorkloadResourceWildcard,
-						"service_endpoint.host",
+						serverWorkloadEndpointHost,
 						"*.testhost2.com",
 					),
 					resource.TestCheckResourceAttr(

--- a/internal/provider/server_workloads_data_source.go
+++ b/internal/provider/server_workloads_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type serverWorkloadsDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *serverWorkloadsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *serverWorkloadsDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *serverWorkloadsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *serverWorkloadsDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_server_workloads"
 }
 
 // Schema defines the schema for the resource.
-func (d *serverWorkloadsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *serverWorkloadsDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages an server workload.",
 		Attributes: map[string]schema.Attribute{
@@ -146,7 +158,11 @@ func (d *serverWorkloadsDataSource) Schema(_ context.Context, _ datasource.Schem
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *serverWorkloadsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *serverWorkloadsDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.ServerWorkloadsDataSourceModel
 
 	serverWorkloads, err := d.client.GetServerWorkloads(nil)

--- a/internal/provider/server_workloads_data_source_test.go
+++ b/internal/provider/server_workloads_data_source_test.go
@@ -28,7 +28,6 @@ func testFindServerWorkload(resourceName string) resource.TestCheckFunc {
 }
 
 func TestAccServerWorkloadsDataSource(t *testing.T) {
-
 	createFile, _ := os.ReadFile("../../tests/server/data/TestAccServerWorkloadsDataSource.tf")
 	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "Unit Test 1")
 
@@ -40,12 +39,24 @@ func TestAccServerWorkloadsDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Server Workloads returned
-					resource.TestCheckResourceAttrSet(testServerWorkloadsDataSource, "server_workloads.#"),
+					resource.TestCheckResourceAttrSet(
+						testServerWorkloadsDataSource,
+						"server_workloads.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testServerWorkloadsDataSource, "server_workloads.0.id"),
-					resource.TestCheckResourceAttrSet(testServerWorkloadsDataSource, "server_workloads.0.service_endpoint.external_id"),
+					resource.TestCheckResourceAttrSet(
+						testServerWorkloadsDataSource,
+						"server_workloads.0.id",
+					),
+					resource.TestCheckResourceAttrSet(
+						testServerWorkloadsDataSource,
+						"server_workloads.0.service_endpoint.external_id",
+					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet(testServerWorkloadsDataSource, "server_workloads.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testServerWorkloadsDataSource,
+						"server_workloads.0.id",
+					),
 					// Find newly created entry
 					testFindServerWorkload(testServerWorkloadResource),
 				),

--- a/internal/provider/signin_policy_resource.go
+++ b/internal/provider/signin_policy_resource.go
@@ -2,13 +2,13 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -29,17 +29,29 @@ type SignInPolicyResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *SignInPolicyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *SignInPolicyResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_signin_policy"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *SignInPolicyResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *SignInPolicyResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *SignInPolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *SignInPolicyResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -60,7 +72,11 @@ func (r *SignInPolicyResource) Schema(_ context.Context, _ resource.SchemaReques
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *SignInPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *SignInPolicyResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.SignInPolicyResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -81,7 +97,11 @@ func (r *SignInPolicyResource) Read(ctx context.Context, req resource.ReadReques
 	}
 }
 
-func (r *SignInPolicyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *SignInPolicyResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Get refreshed signInPolicy value from Aembit
 	signInPolicy, _, _ := r.client.GetSignInPolicy(nil)
 	state := convertSignInPolicyDTOToModel(ctx, signInPolicy, r.client.Tenant)
@@ -90,7 +110,11 @@ func (r *SignInPolicyResource) ImportState(ctx context.Context, req resource.Imp
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *SignInPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *SignInPolicyResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.SignInPolicyResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -107,7 +131,7 @@ func (r *SignInPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	var signInPolicy aembit.GetSignInPolicyDTO = convertSignInPolicyModelToDTO(ctx, &plan, r.client.Tenant)
+	signInPolicy := convertSignInPolicyModelToDTO(ctx, &plan, r.client.Tenant)
 	updateSignInResponse, err := UpdateSignInSettings(r.client, &signInPolicy)
 	if err != nil {
 		addResponseError(&resp.Diagnostics, err)
@@ -126,9 +150,15 @@ func (r *SignInPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 }
 
-func (r *SignInPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-
-	resp.Diagnostics.AddWarning("Setting Tenant SignIn Policy Configuration", "The Aembit SignIn Policy is a tenant-wide configuration and cannot be defined in multiple Resource Sets. Please be sure to only define a single aembit_signin_policy resource per Aembit tenant.")
+func (r *SignInPolicyResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
+	resp.Diagnostics.AddWarning(
+		"Setting Tenant SignIn Policy Configuration",
+		"The Aembit SignIn Policy is a tenant-wide configuration and cannot be defined in multiple Resource Sets. Please be sure to only define a single aembit_signin_policy resource per Aembit tenant.",
+	)
 
 	// Retrieve values from plan
 	var plan models.SignInPolicyResourceModel
@@ -138,7 +168,7 @@ func (r *SignInPolicyResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	var signInPolicy aembit.GetSignInPolicyDTO = convertSignInPolicyModelToDTO(ctx, &plan, r.client.Tenant)
+	signInPolicy := convertSignInPolicyModelToDTO(ctx, &plan, r.client.Tenant)
 	updateSignInResponse, err := UpdateSignInSettings(r.client, &signInPolicy)
 	if err != nil {
 		addResponseError(&resp.Diagnostics, err)
@@ -158,8 +188,15 @@ func (r *SignInPolicyResource) Create(ctx context.Context, req resource.CreateRe
 	// set and return the state
 }
 
-func (r *SignInPolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddWarning("Resetting SignIn Policy to Non-Enforcing Default", "The Aembit SignIn Policy cannot be deleted, only reset to it's original non-enforcing default state.")
+func (r *SignInPolicyResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
+	resp.Diagnostics.AddWarning(
+		"Resetting SignIn Policy to Non-Enforcing Default",
+		"The Aembit SignIn Policy cannot be deleted, only reset to it's original non-enforcing default state.",
+	)
 
 	// Retrieve values from state
 	var state models.SignInPolicyResourceModel
@@ -169,7 +206,10 @@ func (r *SignInPolicyResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	_, err := UpdateSignInSettings(r.client, &aembit.GetSignInPolicyDTO{SSORequired: false, MFARequired: false})
+	_, err := UpdateSignInSettings(
+		r.client,
+		&aembit.GetSignInPolicyDTO{SSORequired: false, MFARequired: false},
+	)
 	if err != nil {
 		addResponseError(&resp.Diagnostics, err)
 		return
@@ -187,7 +227,10 @@ func (r *SignInPolicyResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 }
 
-func UpdateSignInSettings(client *aembit.CloudClient, dto *aembit.GetSignInPolicyDTO) (*aembit.GetSignInPolicyDTO, error) {
+func UpdateSignInSettings(
+	client *aembit.CloudClient,
+	dto *aembit.GetSignInPolicyDTO,
+) (*aembit.GetSignInPolicyDTO, error) {
 	mfaRequestDTO := aembit.MFASignInPolicyDTO{MFARequired: dto.MFARequired}
 	mfaResponseDTO, err := client.UpdateSignInPolicyMFA(mfaRequestDTO, nil)
 	if err != nil {
@@ -200,11 +243,18 @@ func UpdateSignInSettings(client *aembit.CloudClient, dto *aembit.GetSignInPolic
 		return nil, err
 	}
 
-	return &aembit.GetSignInPolicyDTO{SSORequired: ssoResponseDTO.SSORequired, MFARequired: mfaResponseDTO.MFARequired}, nil
+	return &aembit.GetSignInPolicyDTO{
+		SSORequired: ssoResponseDTO.SSORequired,
+		MFARequired: mfaResponseDTO.MFARequired,
+	}, nil
 }
 
 // Model to DTO conversion methods.
-func convertSignInPolicyModelToDTO(_ context.Context, model *models.SignInPolicyResourceModel, tenantId string) aembit.GetSignInPolicyDTO {
+func convertSignInPolicyModelToDTO(
+	_ context.Context,
+	model *models.SignInPolicyResourceModel,
+	tenantId string,
+) aembit.GetSignInPolicyDTO {
 	var dto aembit.GetSignInPolicyDTO
 	dto.MFARequired = model.MFARequired.ValueBool()
 	dto.SSORequired = model.SSORequired.ValueBool()
@@ -213,7 +263,11 @@ func convertSignInPolicyModelToDTO(_ context.Context, model *models.SignInPolicy
 }
 
 // DTO to Model conversion methods.
-func convertSignInPolicyDTOToModel(_ context.Context, dto aembit.GetSignInPolicyDTO, tenantId string) models.SignInPolicyResourceModel {
+func convertSignInPolicyDTOToModel(
+	_ context.Context,
+	dto aembit.GetSignInPolicyDTO,
+	tenantId string,
+) models.SignInPolicyResourceModel {
 	var model models.SignInPolicyResourceModel
 	model.MFARequired = types.BoolValue(dto.MFARequired)
 	model.SSORequired = types.BoolValue(dto.SSORequired)

--- a/internal/provider/standalone_certificate_authorities_data_source.go
+++ b/internal/provider/standalone_certificate_authorities_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type standaloneCertificateAuthoritiesDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *standaloneCertificateAuthoritiesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *standaloneCertificateAuthoritiesDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *standaloneCertificateAuthoritiesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *standaloneCertificateAuthoritiesDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_standalone_certificate_authorities"
 }
 
 // Schema defines the schema for the resource.
-func (d *standaloneCertificateAuthoritiesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *standaloneCertificateAuthoritiesDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages a standalone certificate authority.",
 		Attributes: map[string]schema.Attribute{
@@ -94,7 +106,11 @@ func (d *standaloneCertificateAuthoritiesDataSource) Schema(_ context.Context, _
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *standaloneCertificateAuthoritiesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *standaloneCertificateAuthoritiesDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.StandaloneCertificateAuthoritiesDataSourceModel
 
 	standaloneCertificates, err := d.client.GetStandaloneCertificates(nil)
@@ -108,8 +124,14 @@ func (d *standaloneCertificateAuthoritiesDataSource) Read(ctx context.Context, r
 
 	// Map response body to model
 	for _, standaloneCertificate := range standaloneCertificates {
-		standaloneCertificateState := convertStandaloneCertificateDTOToModel(ctx, standaloneCertificate)
-		state.StandaloneCertificates = append(state.StandaloneCertificates, standaloneCertificateState)
+		standaloneCertificateState := convertStandaloneCertificateDTOToModel(
+			ctx,
+			standaloneCertificate,
+		)
+		state.StandaloneCertificates = append(
+			state.StandaloneCertificates,
+			standaloneCertificateState,
+		)
 	}
 
 	// Set state

--- a/internal/provider/standalone_certificate_authorities_data_source_test.go
+++ b/internal/provider/standalone_certificate_authorities_data_source_test.go
@@ -28,8 +28,9 @@ func testFindStandaloneCertificate(resourceName string) resource.TestCheckFunc {
 }
 
 func TestAccStandaloneCertificatesDataSource(t *testing.T) {
-
-	createFile, _ := os.ReadFile("../../tests/standalone_certificate_authority/data/TestAccStandaloneCertificatesDataSource.tf")
+	createFile, _ := os.ReadFile(
+		"../../tests/standalone_certificate_authority/data/TestAccStandaloneCertificatesDataSource.tf",
+	)
 	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "Unit Test 1")
 
 	resource.Test(t, resource.TestCase{
@@ -40,13 +41,28 @@ func TestAccStandaloneCertificatesDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Standalone Certificate Authorities returned
-					resource.TestCheckResourceAttrSet(testStandaloneCertificatesDataSource, "standalone_certificate_authorities.#"),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificatesDataSource,
+						"standalone_certificate_authorities.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testStandaloneCertificatesDataSource, "standalone_certificate_authorities.0.id"),
-					resource.TestCheckResourceAttrSet(testStandaloneCertificatesDataSource, "standalone_certificate_authorities.0.not_before"),
-					resource.TestCheckResourceAttrSet(testStandaloneCertificatesDataSource, "standalone_certificate_authorities.0.not_after"),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificatesDataSource,
+						"standalone_certificate_authorities.0.id",
+					),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificatesDataSource,
+						"standalone_certificate_authorities.0.not_before",
+					),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificatesDataSource,
+						"standalone_certificate_authorities.0.not_after",
+					),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet(testStandaloneCertificatesDataSource, "standalone_certificate_authorities.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificatesDataSource,
+						"standalone_certificate_authorities.0.id",
+					),
 					// Find newly created entry
 					testFindStandaloneCertificate(testStandaloneCertificateResource),
 				),

--- a/internal/provider/standalone_certificate_authority_resource.go
+++ b/internal/provider/standalone_certificate_authority_resource.go
@@ -262,7 +262,7 @@ func convertStandaloneCertificateModelToDTO(ctx context.Context, model models.St
 	standaloneCertificate.NotAfter = model.NotAfter.ValueString()
 
 	if externalID != nil {
-		standaloneCertificate.EntityDTO.ExternalID = *externalID
+		standaloneCertificate.ExternalID = *externalID
 	}
 
 	return standaloneCertificate
@@ -270,10 +270,10 @@ func convertStandaloneCertificateModelToDTO(ctx context.Context, model models.St
 
 func convertStandaloneCertificateDTOToModel(ctx context.Context, dto aembit.StandaloneCertificateDTO) models.StandaloneCertificateAuthorityResourceModel {
 	var model models.StandaloneCertificateAuthorityResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 	model.LeafLifetime = types.Int32Value(dto.LeafLifetime)
 	model.NotBefore = types.StringValue(dto.NotBefore)
 	model.NotAfter = types.StringValue(dto.NotAfter)

--- a/internal/provider/standalone_certificate_authority_resource.go
+++ b/internal/provider/standalone_certificate_authority_resource.go
@@ -3,8 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
@@ -13,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -33,17 +33,29 @@ type standaloneCertificateAuthorityResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *standaloneCertificateAuthorityResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *standaloneCertificateAuthorityResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_standalone_certificate_authority"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *standaloneCertificateAuthorityResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *standaloneCertificateAuthorityResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *standaloneCertificateAuthorityResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *standaloneCertificateAuthorityResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// ID field is required for Terraform Framework acceptance testing.
@@ -99,7 +111,11 @@ func (r *standaloneCertificateAuthorityResource) Schema(_ context.Context, _ res
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *standaloneCertificateAuthorityResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *standaloneCertificateAuthorityResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.StandaloneCertificateAuthorityResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -109,10 +125,13 @@ func (r *standaloneCertificateAuthorityResource) Create(ctx context.Context, req
 	}
 
 	// Generate API request body from plan
-	var standaloneCertificate aembit.StandaloneCertificateDTO = convertStandaloneCertificateModelToDTO(ctx, plan, nil)
+	standaloneCertificate := convertStandaloneCertificateModelToDTO(ctx, plan, nil)
 
 	// Create new Standalone Certificate Authority
-	standaloneCertificateResponse, err := r.client.CreateStandaloneCertificate(standaloneCertificate, nil)
+	standaloneCertificateResponse, err := r.client.CreateStandaloneCertificate(
+		standaloneCertificate,
+		nil,
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Standalone Certificate Authority",
@@ -133,7 +152,11 @@ func (r *standaloneCertificateAuthorityResource) Create(ctx context.Context, req
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *standaloneCertificateAuthorityResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *standaloneCertificateAuthorityResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.StandaloneCertificateAuthorityResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -143,11 +166,18 @@ func (r *standaloneCertificateAuthorityResource) Read(ctx context.Context, req r
 	}
 
 	// Get refreshed workload value from Aembit
-	standaloneCertificate, err, notFound := r.client.GetStandaloneCertificate(state.ID.ValueString(), nil)
+	standaloneCertificate, err, notFound := r.client.GetStandaloneCertificate(
+		state.ID.ValueString(),
+		nil,
+	)
 	if err != nil {
 		resp.Diagnostics.AddWarning(
 			"Error reading Standalone Certificate Authority",
-			fmt.Sprintf("An error occurred while attempting to fetch the Standalone Certificate Authority with External ID '%s' from Terraform state: %v", state.ID.ValueString(), err.Error()),
+			fmt.Sprintf(
+				"An error occurred while attempting to fetch the Standalone Certificate Authority with External ID '%s' from Terraform state: %v",
+				state.ID.ValueString(),
+				err.Error(),
+			),
 		)
 
 		// If the resource is not found on Aembit Cloud, delete it locally
@@ -169,7 +199,11 @@ func (r *standaloneCertificateAuthorityResource) Read(ctx context.Context, req r
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *standaloneCertificateAuthorityResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *standaloneCertificateAuthorityResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.StandaloneCertificateAuthorityResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -179,7 +213,7 @@ func (r *standaloneCertificateAuthorityResource) Update(ctx context.Context, req
 	}
 
 	// Extract external ID from state
-	var externalID string = state.ID.ValueString()
+	externalID := state.ID.ValueString()
 
 	// Retrieve values from plan
 	var plan models.StandaloneCertificateAuthorityResourceModel
@@ -190,7 +224,7 @@ func (r *standaloneCertificateAuthorityResource) Update(ctx context.Context, req
 	}
 
 	// Generate API request body from plan
-	var workload aembit.StandaloneCertificateDTO = convertStandaloneCertificateModelToDTO(ctx, plan, &externalID)
+	workload := convertStandaloneCertificateModelToDTO(ctx, plan, &externalID)
 
 	// Update Standalone Certificate Authority
 	serverWorkload, err := r.client.UpdateStandaloneCertificate(workload, nil)
@@ -214,7 +248,11 @@ func (r *standaloneCertificateAuthorityResource) Update(ctx context.Context, req
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *standaloneCertificateAuthorityResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *standaloneCertificateAuthorityResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.StandaloneCertificateAuthorityResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -235,12 +273,20 @@ func (r *standaloneCertificateAuthorityResource) Delete(ctx context.Context, req
 }
 
 // Imports an existing resource by passing externalID.
-func (r *standaloneCertificateAuthorityResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *standaloneCertificateAuthorityResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalID and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func convertStandaloneCertificateModelToDTO(ctx context.Context, model models.StandaloneCertificateAuthorityResourceModel, externalID *string) aembit.StandaloneCertificateDTO {
+func convertStandaloneCertificateModelToDTO(
+	ctx context.Context,
+	model models.StandaloneCertificateAuthorityResourceModel,
+	externalID *string,
+) aembit.StandaloneCertificateDTO {
 	var standaloneCertificate aembit.StandaloneCertificateDTO
 	standaloneCertificate.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -268,7 +314,10 @@ func convertStandaloneCertificateModelToDTO(ctx context.Context, model models.St
 	return standaloneCertificate
 }
 
-func convertStandaloneCertificateDTOToModel(ctx context.Context, dto aembit.StandaloneCertificateDTO) models.StandaloneCertificateAuthorityResourceModel {
+func convertStandaloneCertificateDTOToModel(
+	ctx context.Context,
+	dto aembit.StandaloneCertificateDTO,
+) models.StandaloneCertificateAuthorityResourceModel {
 	var model models.StandaloneCertificateAuthorityResourceModel
 	model.ID = types.StringValue(dto.ExternalID)
 	model.Name = types.StringValue(dto.Name)

--- a/internal/provider/standalone_certificate_authority_resource_test.go
+++ b/internal/provider/standalone_certificate_authority_resource_test.go
@@ -10,9 +10,17 @@ import (
 const testStandaloneCertificateResource string = "aembit_standalone_certificate_authority.test"
 
 func TestAccStandaloneCertificateAuthorityResource(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/standalone_certificate_authority/TestAccStandaloneCertificateAuthorityResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/standalone_certificate_authority/TestAccStandaloneCertificateAuthorityResource.tfmod")
-	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(string(createFile), string(modifyFile), "unittestname")
+	createFile, _ := os.ReadFile(
+		"../../tests/standalone_certificate_authority/TestAccStandaloneCertificateAuthorityResource.tf",
+	)
+	modifyFile, _ := os.ReadFile(
+		"../../tests/standalone_certificate_authority/TestAccStandaloneCertificateAuthorityResource.tfmod",
+	)
+	createFileConfig, modifyFileConfig, newName := randomizeFileConfigs(
+		string(createFile),
+		string(modifyFile),
+		"unittestname",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -22,39 +30,111 @@ func TestAccStandaloneCertificateAuthorityResource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "name", newName),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"name",
+						newName,
+					),
 					// Verify Tags
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, tagsCount, "2"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, tagsColor, "blue"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, tagsDay, "Sunday"),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						tagsColor,
+						"blue",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						tagsDay,
+						"Sunday",
+					),
 					// Verify Metadata
-					resource.TestCheckResourceAttrSet(testStandaloneCertificateResource, "not_before"),
-					resource.TestCheckResourceAttrSet(testStandaloneCertificateResource, "not_after"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "leaf_lifetime", "1440"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "client_workload_count", "0"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "resource_set_count", "0"),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificateResource,
+						"not_before",
+					),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificateResource,
+						"not_after",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"leaf_lifetime",
+						"1440",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"client_workload_count",
+						"0",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"resource_set_count",
+						"0",
+					),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(testStandaloneCertificateResource, "id"),
 				),
 			},
 			// ImportState testing
-			{ResourceName: testStandaloneCertificateResource, ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      testStandaloneCertificateResource,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: modifyFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "name", newName+" - Modified"),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"name",
+						newName+" - Modified",
+					),
 					// Verify Tags.
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, tagsCount, "2"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, tagsColor, "orange"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, tagsDay, "Tuesday"),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						tagsColor,
+						"orange",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						tagsDay,
+						"Tuesday",
+					),
 					// Verify Metadata.
-					resource.TestCheckResourceAttrSet(testStandaloneCertificateResource, "not_before"),
-					resource.TestCheckResourceAttrSet(testStandaloneCertificateResource, "not_after"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "leaf_lifetime", "60"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "client_workload_count", "0"),
-					resource.TestCheckResourceAttr(testStandaloneCertificateResource, "resource_set_count", "0"),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificateResource,
+						"not_before",
+					),
+					resource.TestCheckResourceAttrSet(
+						testStandaloneCertificateResource,
+						"not_after",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"leaf_lifetime",
+						"60",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"client_workload_count",
+						"0",
+					),
+					resource.TestCheckResourceAttr(
+						testStandaloneCertificateResource,
+						"resource_set_count",
+						"0",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/test.go
+++ b/internal/provider/test.go
@@ -30,7 +30,7 @@ func checkValidClientID(resourceName, attributeName, arnType string) resource.Te
 			return fmt.Errorf("not found: %s", resourceName)
 		}
 
-		var clientID string = rs.Primary.Attributes[attributeName]
+		var clientID = rs.Primary.Attributes[attributeName]
 		if len(clientID) <= 0 {
 			return fmt.Errorf("empty client id: %s %s", resourceName, attributeName)
 		}

--- a/internal/provider/test.go
+++ b/internal/provider/test.go
@@ -12,15 +12,25 @@ import (
 
 var maxRand = big.NewInt(10000000)
 
-const tagsCount = "tags.%"
-const tagsColor = "tags.color"
-const tagsDay = "tags.day"
+const (
+	tagsCount = "tags.%"
+	tagsColor = "tags.color"
+	tagsDay   = "tags.day"
+)
 
 func randomizeFileConfigs(newConfig, modifyConfig, startValue string) (string, string, string) {
 	randID, _ := rand.Int(rand.Reader, maxRand)
 
 	endValue := fmt.Sprintf("%s%d", startValue, randID)
-	return strings.ReplaceAll(newConfig, startValue, endValue), strings.ReplaceAll(modifyConfig, startValue, endValue), endValue
+	return strings.ReplaceAll(
+			newConfig,
+			startValue,
+			endValue,
+		), strings.ReplaceAll(
+			modifyConfig,
+			startValue,
+			endValue,
+		), endValue
 }
 
 func checkValidClientID(resourceName, attributeName, arnType string) resource.TestCheckFunc {
@@ -30,7 +40,7 @@ func checkValidClientID(resourceName, attributeName, arnType string) resource.Te
 			return fmt.Errorf("not found: %s", resourceName)
 		}
 
-		var clientID = rs.Primary.Attributes[attributeName]
+		clientID := rs.Primary.Attributes[attributeName]
 		if len(clientID) <= 0 {
 			return fmt.Errorf("empty client id: %s %s", resourceName, attributeName)
 		}

--- a/internal/provider/timezone_data_source.go
+++ b/internal/provider/timezone_data_source.go
@@ -26,17 +26,29 @@ type timezonesDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *timezonesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *timezonesDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *timezonesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *timezonesDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_timezones"
 }
 
 // Schema defines the schema for the resource.
-func (d *timezonesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *timezonesDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "List of available timezones, including their UTC offset, region grouping, and a user-friendly label.",
 		Attributes: map[string]schema.Attribute{
@@ -65,7 +77,11 @@ func (d *timezonesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *timezonesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *timezonesDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	state := GetTimezones(d.client)
 	// Set state
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/trust_provider_resource.go
+++ b/internal/provider/trust_provider_resource.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"terraform-provider-aembit/internal/provider/models"
-	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -22,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"terraform-provider-aembit/internal/provider/models"
+	"terraform-provider-aembit/internal/provider/validators"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -42,17 +42,29 @@ type trustProviderResource struct {
 }
 
 // Metadata returns the resource type name.
-func (r *trustProviderResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *trustProviderResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_trust_provider"
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *trustProviderResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *trustProviderResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
 	r.client = resourceConfigure(req, resp)
 }
 
 // Schema defines the schema for the resource.
-func (r *trustProviderResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *trustProviderResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "**Note:** One and only one nested schema (e.g. `aws_metadata`) must be provided for the Trust Provider to be configured.",
 		Attributes: map[string]schema.Attribute{
@@ -869,7 +881,11 @@ func (r *trustProviderResource) ConfigValidators(_ context.Context) []resource.C
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *trustProviderResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *trustProviderResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
 	// Retrieve values from plan
 	var plan models.TrustProviderResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -879,7 +895,7 @@ func (r *trustProviderResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Generate API request body from plan
-	var trust, err = convertTrustProviderModelToDTO(ctx, plan, nil)
+	trust, err := convertTrustProviderModelToDTO(ctx, plan, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Trust Provider",
@@ -899,7 +915,12 @@ func (r *trustProviderResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Map response body to schema and populate Computed attribute values
-	plan = convertTrustProviderDTOToModel(ctx, *trustProvider, r.client.Tenant, r.client.StackDomain)
+	plan = convertTrustProviderDTOToModel(
+		ctx,
+		*trustProvider,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -910,7 +931,11 @@ func (r *trustProviderResource) Create(ctx context.Context, req resource.CreateR
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (r *trustProviderResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *trustProviderResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
 	// Get current state
 	var state models.TrustProviderResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -934,7 +959,12 @@ func (r *trustProviderResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	state = convertTrustProviderDTOToModel(ctx, trustProvider, r.client.Tenant, r.client.StackDomain)
+	state = convertTrustProviderDTOToModel(
+		ctx,
+		trustProvider,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
@@ -945,7 +975,11 @@ func (r *trustProviderResource) Read(ctx context.Context, req resource.ReadReque
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-func (r *trustProviderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *trustProviderResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
 	// Get current state
 	var state models.TrustProviderResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -966,7 +1000,7 @@ func (r *trustProviderResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	// Generate API request body from plan
-	var trust, err = convertTrustProviderModelToDTO(ctx, plan, &externalID)
+	trust, err := convertTrustProviderModelToDTO(ctx, plan, &externalID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating Trust Provider",
@@ -986,7 +1020,12 @@ func (r *trustProviderResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	// Map response body to schema and populate Computed attribute values
-	state = convertTrustProviderDTOToModel(ctx, *trustProvider, r.client.Tenant, r.client.StackDomain)
+	state = convertTrustProviderDTOToModel(
+		ctx,
+		*trustProvider,
+		r.client.Tenant,
+		r.client.StackDomain,
+	)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, state)
@@ -997,7 +1036,11 @@ func (r *trustProviderResource) Update(ctx context.Context, req resource.UpdateR
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
-func (r *trustProviderResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *trustProviderResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
 	// Retrieve values from state
 	var state models.TrustProviderResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -1030,13 +1073,21 @@ func (r *trustProviderResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 // Imports an existing resource by passing externalId.
-func (r *trustProviderResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *trustProviderResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
 	// Retrieve import externalId and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // Model to DTO conversion methods.
-func convertTrustProviderModelToDTO(ctx context.Context, model models.TrustProviderResourceModel, externalID *string) (aembit.TrustProviderDTO, error) {
+func convertTrustProviderModelToDTO(
+	ctx context.Context,
+	model models.TrustProviderResourceModel,
+	externalID *string,
+) (aembit.TrustProviderDTO, error) {
 	var trust aembit.TrustProviderDTO
 	trust.EntityDTO = aembit.EntityDTO{
 		Name:        model.Name.ValueString(),
@@ -1055,7 +1106,7 @@ func convertTrustProviderModelToDTO(ctx context.Context, model models.TrustProvi
 		}
 	}
 	if externalID != nil {
-		trust.EntityDTO.ExternalID = *externalID
+		trust.ExternalID = *externalID
 	}
 
 	var err error = nil
@@ -1094,7 +1145,11 @@ func convertTrustProviderModelToDTO(ctx context.Context, model models.TrustProvi
 	return trust, err
 }
 
-func appendMatchRuleIfExists(matchRules []aembit.TrustProviderMatchRuleDTO, value basetypes.StringValue, attrName string) []aembit.TrustProviderMatchRuleDTO {
+func appendMatchRuleIfExists(
+	matchRules []aembit.TrustProviderMatchRuleDTO,
+	value basetypes.StringValue,
+	attrName string,
+) []aembit.TrustProviderMatchRuleDTO {
 	if len(value.ValueString()) > 0 {
 		return append(matchRules, aembit.TrustProviderMatchRuleDTO{
 			Attribute: attrName, Value: value.ValueString(),
@@ -1103,7 +1158,11 @@ func appendMatchRuleIfExists(matchRules []aembit.TrustProviderMatchRuleDTO, valu
 	return matchRules
 }
 
-func appendMatchRulesIfExists(matchRules []aembit.TrustProviderMatchRuleDTO, values []basetypes.StringValue, attrName string) []aembit.TrustProviderMatchRuleDTO {
+func appendMatchRulesIfExists(
+	matchRules []aembit.TrustProviderMatchRuleDTO,
+	values []basetypes.StringValue,
+	attrName string,
+) []aembit.TrustProviderMatchRuleDTO {
 	if len(values) > 0 {
 		for _, value := range values {
 			matchRules = appendMatchRuleIfExists(matchRules, value, attrName)
@@ -1112,60 +1171,178 @@ func appendMatchRulesIfExists(matchRules []aembit.TrustProviderMatchRuleDTO, val
 	return matchRules
 }
 
-func convertAzureMetadataModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertAzureMetadataModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "AzureMetadataService"
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AzureMetadata.Sku, "AzureSku")
 	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AzureMetadata.Skus, "AzureSku")
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AzureMetadata.VMID, "AzureVmId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AzureMetadata.VMIDs, "AzureVmId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AzureMetadata.SubscriptionID, "AzureSubscriptionId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AzureMetadata.SubscriptionIDs, "AzureSubscriptionId")
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AzureMetadata.VMIDs,
+		"AzureVmId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AzureMetadata.SubscriptionID,
+		"AzureSubscriptionId",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AzureMetadata.SubscriptionIDs,
+		"AzureSubscriptionId",
+	)
 }
 
-func convertAwsRoleModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertAwsRoleModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "AWSRole"
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsRole.AccountID, "AwsAccountId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsRole.AccountIDs, "AwsAccountId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsRole.AssumedRole, "AwsAssumedRole")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsRole.AssumedRoles, "AwsAssumedRole")
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsRole.AccountID,
+		"AwsAccountId",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsRole.AccountIDs,
+		"AwsAccountId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsRole.AssumedRole,
+		"AwsAssumedRole",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsRole.AssumedRoles,
+		"AwsAssumedRole",
+	)
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsRole.RoleARN, "AwsRoleARN")
 	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsRole.RoleARNs, "AwsRoleARN")
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsRole.Username, "AwsUsername")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsRole.Usernames, "AwsUsername")
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsRole.Usernames,
+		"AwsUsername",
+	)
 }
 
-func convertAwsMetadataModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertAwsMetadataModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "AWSMetadataService"
-	dto.Certificate = base64.StdEncoding.EncodeToString([]byte(model.AwsMetadata.Certificate.ValueString()))
+	dto.Certificate = base64.StdEncoding.EncodeToString(
+		[]byte(model.AwsMetadata.Certificate.ValueString()),
+	)
 	dto.PemType = "Certificate"
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.AccountID, "AwsAccountId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsMetadata.AccountIDs, "AwsAccountId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.Architecture, "AwsArchitecture")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.AvailabilityZone, "AwsAvailabilityZone")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsMetadata.AvailabilityZones, "AwsAvailabilityZone")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.BillingProducts, "AwsBillingProducts")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.ImageID, "AwsImageId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.InstanceID, "AwsInstanceId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsMetadata.InstanceIDs, "AwsInstanceId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.InstanceType, "AwsInstanceType")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsMetadata.InstanceTypes, "AwsInstanceType")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.KernelID, "AwsKernelId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.MarketplaceProductCodes, "AwsMarketplaceProductCodes")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.PendingTime, "AwsPendingTime")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.PrivateIP, "AwsPrivateIp")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.RamdiskID, "AwsRamdiskId")
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.AccountID,
+		"AwsAccountId",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.AccountIDs,
+		"AwsAccountId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.Architecture,
+		"AwsArchitecture",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.AvailabilityZone,
+		"AwsAvailabilityZone",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.AvailabilityZones,
+		"AwsAvailabilityZone",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.BillingProducts,
+		"AwsBillingProducts",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.ImageID,
+		"AwsImageId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.InstanceID,
+		"AwsInstanceId",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.InstanceIDs,
+		"AwsInstanceId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.InstanceType,
+		"AwsInstanceType",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.InstanceTypes,
+		"AwsInstanceType",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.KernelID,
+		"AwsKernelId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.MarketplaceProductCodes,
+		"AwsMarketplaceProductCodes",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.PendingTime,
+		"AwsPendingTime",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.PrivateIP,
+		"AwsPrivateIp",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.RamdiskID,
+		"AwsRamdiskId",
+	)
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.Region, "AwsRegion")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.AwsMetadata.Regions, "AwsRegion")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.AwsMetadata.Version, "AwsVersion")
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.Regions,
+		"AwsRegion",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.AwsMetadata.Version,
+		"AwsVersion",
+	)
 }
 
-func convertGcpIdentityModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertGcpIdentityModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "GcpIdentityToken"
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
@@ -1173,34 +1350,99 @@ func convertGcpIdentityModelToDTO(model models.TrustProviderResourceModel, dto *
 	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GcpIdentity.EMails, "Email")
 }
 
-func convertGitHubActionModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertGitHubActionModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "GitHubIdentityToken"
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.GitHubAction.Actor, "GithubActor")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GitHubAction.Actors, "GithubActor")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.GitHubAction.Repository, "GithubRepository")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GitHubAction.Repositories, "GithubRepository")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.GitHubAction.Workflow, "GithubWorkflow")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GitHubAction.Workflows, "GithubWorkflow")
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.GitHubAction.Actor,
+		"GithubActor",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.GitHubAction.Actors,
+		"GithubActor",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.GitHubAction.Repository,
+		"GithubRepository",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.GitHubAction.Repositories,
+		"GithubRepository",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.GitHubAction.Workflow,
+		"GithubWorkflow",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.GitHubAction.Workflows,
+		"GithubWorkflow",
+	)
 }
 
-func convertGitLabJobModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertGitLabJobModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "GitLabIdentityToken"
 
 	dto.OidcUrl = model.GitLabJob.OIDCEndpoint.ValueString()
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.GitLabJob.Subject, "GitLabSubject")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GitLabJob.Subjects, "GitLabSubject")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.GitLabJob.ProjectPath, "GitLabProjectPath")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GitLabJob.ProjectPaths, "GitLabProjectPath")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.GitLabJob.NamespacePath, "GitLabNamespacePath")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GitLabJob.NamespacePaths, "GitLabNamespacePath")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.GitLabJob.RefPath, "GitLabRefPath")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.GitLabJob.RefPaths, "GitLabRefPath")
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.GitLabJob.Subject,
+		"GitLabSubject",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.GitLabJob.Subjects,
+		"GitLabSubject",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.GitLabJob.ProjectPath,
+		"GitLabProjectPath",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.GitLabJob.ProjectPaths,
+		"GitLabProjectPath",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.GitLabJob.NamespacePath,
+		"GitLabNamespacePath",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.GitLabJob.NamespacePaths,
+		"GitLabNamespacePath",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.GitLabJob.RefPath,
+		"GitLabRefPath",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.GitLabJob.RefPaths,
+		"GitLabRefPath",
+	)
 }
 
-func convertKerberosModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertKerberosModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "Kerberos"
 	dto.AgentControllerIDs = make([]string, len(model.Kerberos.AgentControllerIDs))
 	for i, controllerID := range model.Kerberos.AgentControllerIDs {
@@ -1209,16 +1451,33 @@ func convertKerberosModelToDTO(model models.TrustProviderResourceModel, dto *aem
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.Kerberos.Principal, "Principal")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.Kerberos.Principals, "Principal")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.Kerberos.RealmOrDomain, "RealmOrDomain")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.Kerberos.RealmsOrDomains, "RealmOrDomain")
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.Kerberos.Principals,
+		"Principal",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.Kerberos.RealmOrDomain,
+		"RealmOrDomain",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.Kerberos.RealmsOrDomains,
+		"RealmOrDomain",
+	)
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.Kerberos.SourceIP, "SourceIp")
 	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.Kerberos.SourceIPs, "SourceIp")
 }
 
-func convertKubernetesModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) error {
+func convertKubernetesModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) error {
 	dto.Provider = "KubernetesServiceAccount"
-	dto.Certificate = base64.StdEncoding.EncodeToString([]byte(model.KubernetesService.PublicKey.ValueString()))
+	dto.Certificate = base64.StdEncoding.EncodeToString(
+		[]byte(model.KubernetesService.PublicKey.ValueString()),
+	)
 	if len(dto.Certificate) > 0 {
 		dto.PemType = "PublicKey"
 	}
@@ -1230,23 +1489,68 @@ func convertKubernetesModelToDTO(model models.TrustProviderResourceModel, dto *a
 	}
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.KubernetesService.Issuer, "KubernetesIss")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.KubernetesService.Issuers, "KubernetesIss")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.KubernetesService.Namespace, "KubernetesIoNamespace")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.KubernetesService.Namespaces, "KubernetesIoNamespace")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.KubernetesService.PodName, "KubernetesIoPodName")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.KubernetesService.PodNames, "KubernetesIoPodName")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.KubernetesService.ServiceAccountName, "KubernetesIoServiceAccountName")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.KubernetesService.ServiceAccountNames, "KubernetesIoServiceAccountName")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.KubernetesService.Subject, "KubernetesSub")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.KubernetesService.Subjects, "KubernetesSub")
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.KubernetesService.Issuer,
+		"KubernetesIss",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.KubernetesService.Issuers,
+		"KubernetesIss",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.KubernetesService.Namespace,
+		"KubernetesIoNamespace",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.KubernetesService.Namespaces,
+		"KubernetesIoNamespace",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.KubernetesService.PodName,
+		"KubernetesIoPodName",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.KubernetesService.PodNames,
+		"KubernetesIoPodName",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.KubernetesService.ServiceAccountName,
+		"KubernetesIoServiceAccountName",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.KubernetesService.ServiceAccountNames,
+		"KubernetesIoServiceAccountName",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.KubernetesService.Subject,
+		"KubernetesSub",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.KubernetesService.Subjects,
+		"KubernetesSub",
+	)
 
 	return nil
 }
 
-func convertOidcIdTokenTpModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) error {
+func convertOidcIdTokenTpModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) error {
 	dto.Provider = "OidcIdToken"
-	dto.Certificate = base64.StdEncoding.EncodeToString([]byte(model.OidcIdToken.PublicKey.ValueString()))
+	dto.Certificate = base64.StdEncoding.EncodeToString(
+		[]byte(model.OidcIdToken.PublicKey.ValueString()),
+	)
 	if len(dto.Certificate) > 0 {
 		dto.PemType = "PublicKey"
 	}
@@ -1258,11 +1562,31 @@ func convertOidcIdTokenTpModelToDTO(model models.TrustProviderResourceModel, dto
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
 	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.OidcIdToken.Issuer, "OidcIssuer")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.OidcIdToken.Issuers, "OidcIssuer")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.OidcIdToken.Subject, "OidcSubject")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.OidcIdToken.Subjects, "OidcSubject")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.OidcIdToken.Audience, "OidcAudience")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.OidcIdToken.Audiences, "OidcAudience")
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.OidcIdToken.Issuers,
+		"OidcIssuer",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.OidcIdToken.Subject,
+		"OidcSubject",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.OidcIdToken.Subjects,
+		"OidcSubject",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.OidcIdToken.Audience,
+		"OidcAudience",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.OidcIdToken.Audiences,
+		"OidcAudience",
+	)
 
 	return nil
 }
@@ -1309,20 +1633,51 @@ func convertJWKSModelToDto(jwksJson string, dto *aembit.TrustProviderDTO) error 
 	return nil
 }
 
-func convertTerraformModelToDTO(model models.TrustProviderResourceModel, dto *aembit.TrustProviderDTO) {
+func convertTerraformModelToDTO(
+	model models.TrustProviderResourceModel,
+	dto *aembit.TrustProviderDTO,
+) {
 	dto.Provider = "TerraformIdentityToken"
 
 	dto.MatchRules = make([]aembit.TrustProviderMatchRuleDTO, 0)
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.TerraformWorkspace.OrganizationID, "TerraformOrganizationId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.TerraformWorkspace.OrganizationIDs, "TerraformOrganizationId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.TerraformWorkspace.ProjectID, "TerraformProjectId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.TerraformWorkspace.ProjectIDs, "TerraformProjectId")
-	dto.MatchRules = appendMatchRuleIfExists(dto.MatchRules, model.TerraformWorkspace.WorkspaceID, "TerraformWorkspaceId")
-	dto.MatchRules = appendMatchRulesIfExists(dto.MatchRules, model.TerraformWorkspace.WorkspaceIDs, "TerraformWorkspaceId")
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.TerraformWorkspace.OrganizationID,
+		"TerraformOrganizationId",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.TerraformWorkspace.OrganizationIDs,
+		"TerraformOrganizationId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.TerraformWorkspace.ProjectID,
+		"TerraformProjectId",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.TerraformWorkspace.ProjectIDs,
+		"TerraformProjectId",
+	)
+	dto.MatchRules = appendMatchRuleIfExists(
+		dto.MatchRules,
+		model.TerraformWorkspace.WorkspaceID,
+		"TerraformWorkspaceId",
+	)
+	dto.MatchRules = appendMatchRulesIfExists(
+		dto.MatchRules,
+		model.TerraformWorkspace.WorkspaceIDs,
+		"TerraformWorkspaceId",
+	)
 }
 
 // DTO to Model conversion methods.
-func convertTrustProviderDTOToModel(ctx context.Context, dto aembit.TrustProviderDTO, tenant, stackDomain string) models.TrustProviderResourceModel {
+func convertTrustProviderDTOToModel(
+	ctx context.Context,
+	dto aembit.TrustProviderDTO,
+	tenant, stackDomain string,
+) models.TrustProviderResourceModel {
 	var model models.TrustProviderResourceModel
 	model.ID = types.StringValue(dto.ExternalID)
 	model.Name = types.StringValue(dto.Name)
@@ -1356,7 +1711,9 @@ func convertTrustProviderDTOToModel(ctx context.Context, dto aembit.TrustProvide
 	return model
 }
 
-func convertAzureMetadataDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProviderAzureMetadataModel {
+func convertAzureMetadataDTOToModel(
+	dto aembit.TrustProviderDTO,
+) *models.TrustProviderAzureMetadataModel {
 	model := &models.TrustProviderAzureMetadataModel{
 		Sku:            types.StringNull(),
 		VMID:           types.StringNull(),
@@ -1370,7 +1727,10 @@ func convertAzureMetadataDTOToModel(dto aembit.TrustProviderDTO) *models.TrustPr
 		model.VMID, model.VMIDs = extractMatchRules(dto.MatchRules, "AzureVmId")
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("AzureSubscriptionId")) {
-		model.SubscriptionID, model.SubscriptionIDs = extractMatchRules(dto.MatchRules, "AzureSubscriptionId")
+		model.SubscriptionID, model.SubscriptionIDs = extractMatchRules(
+			dto.MatchRules,
+			"AzureSubscriptionId",
+		)
 	}
 	return model
 }
@@ -1398,7 +1758,9 @@ func convertAwsRoleDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProvider
 	return model
 }
 
-func convertAwsMetadataDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProviderAwsMetadataModel {
+func convertAwsMetadataDTOToModel(
+	dto aembit.TrustProviderDTO,
+) *models.TrustProviderAwsMetadataModel {
 	decodedCert, _ := base64.StdEncoding.DecodeString(dto.Certificate)
 
 	model := &models.TrustProviderAwsMetadataModel{
@@ -1426,7 +1788,10 @@ func convertAwsMetadataDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProv
 		model.Architecture, _ = extractMatchRules(dto.MatchRules, "AwsArchitecture")
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("AwsAvailabilityZone")) {
-		model.AvailabilityZone, model.AvailabilityZones = extractMatchRules(dto.MatchRules, "AwsAvailabilityZone")
+		model.AvailabilityZone, model.AvailabilityZones = extractMatchRules(
+			dto.MatchRules,
+			"AwsAvailabilityZone",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("AwsBillingProducts")) {
 		model.BillingProducts, _ = extractMatchRules(dto.MatchRules, "AwsBillingProducts")
@@ -1438,13 +1803,19 @@ func convertAwsMetadataDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProv
 		model.InstanceID, model.InstanceIDs = extractMatchRules(dto.MatchRules, "AwsInstanceId")
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("AwsInstanceType")) {
-		model.InstanceType, model.InstanceTypes = extractMatchRules(dto.MatchRules, "AwsInstanceType")
+		model.InstanceType, model.InstanceTypes = extractMatchRules(
+			dto.MatchRules,
+			"AwsInstanceType",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("AwsKernelId")) {
 		model.KernelID, _ = extractMatchRules(dto.MatchRules, "AwsKernelId")
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("AwsMarketplaceProductCodes")) {
-		model.MarketplaceProductCodes, _ = extractMatchRules(dto.MatchRules, "AwsMarketplaceProductCodes")
+		model.MarketplaceProductCodes, _ = extractMatchRules(
+			dto.MatchRules,
+			"AwsMarketplaceProductCodes",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("AwsPendingTime")) {
 		model.PendingTime, _ = extractMatchRules(dto.MatchRules, "AwsPendingTime")
@@ -1513,13 +1884,22 @@ func convertKubernetesDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProvi
 		model.Issuer, model.Issuers = extractMatchRules(dto.MatchRules, "KubernetesIss")
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("KubernetesIoNamespace")) {
-		model.Namespace, model.Namespaces = extractMatchRules(dto.MatchRules, "KubernetesIoNamespace")
+		model.Namespace, model.Namespaces = extractMatchRules(
+			dto.MatchRules,
+			"KubernetesIoNamespace",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("KubernetesIoPodName")) {
 		model.PodName, model.PodNames = extractMatchRules(dto.MatchRules, "KubernetesIoPodName")
 	}
-	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("KubernetesIoServiceAccountName")) {
-		model.ServiceAccountName, model.ServiceAccountNames = extractMatchRules(dto.MatchRules, "KubernetesIoServiceAccountName")
+	if slices.ContainsFunc(
+		dto.MatchRules,
+		matchRuleAttributeFunc("KubernetesIoServiceAccountName"),
+	) {
+		model.ServiceAccountName, model.ServiceAccountNames = extractMatchRules(
+			dto.MatchRules,
+			"KubernetesIoServiceAccountName",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("KubernetesSub")) {
 		model.Subject, model.Subjects = extractMatchRules(dto.MatchRules, "KubernetesSub")
@@ -1527,7 +1907,9 @@ func convertKubernetesDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProvi
 	return model
 }
 
-func convertOidcIdTokenTpDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProviderOidcIdTokenModel {
+func convertOidcIdTokenTpDTOToModel(
+	dto aembit.TrustProviderDTO,
+) *models.TrustProviderOidcIdTokenModel {
 	decodedKey, _ := base64.StdEncoding.DecodeString(dto.Certificate)
 
 	model := &models.TrustProviderOidcIdTokenModel{
@@ -1558,7 +1940,9 @@ func convertOidcIdTokenTpDTOToModel(dto aembit.TrustProviderDTO) *models.TrustPr
 	return model
 }
 
-func convertGcpIdentityDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProviderGcpIdentityModel {
+func convertGcpIdentityDTOToModel(
+	dto aembit.TrustProviderDTO,
+) *models.TrustProviderGcpIdentityModel {
 	model := &models.TrustProviderGcpIdentityModel{
 		EMail: types.StringNull(),
 	}
@@ -1569,7 +1953,9 @@ func convertGcpIdentityDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProv
 	return model
 }
 
-func convertGitHubActionDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProviderGitHubActionModel {
+func convertGitHubActionDTOToModel(
+	dto aembit.TrustProviderDTO,
+) *models.TrustProviderGitHubActionModel {
 	model := &models.TrustProviderGitHubActionModel{
 		Actor:      types.StringNull(),
 		Repository: types.StringNull(),
@@ -1588,7 +1974,10 @@ func convertGitHubActionDTOToModel(dto aembit.TrustProviderDTO) *models.TrustPro
 	return model
 }
 
-func convertGitLabJobDTOToModel(dto aembit.TrustProviderDTO, tenant, stackDomain string) *models.TrustProviderGitLabJobModel {
+func convertGitLabJobDTOToModel(
+	dto aembit.TrustProviderDTO,
+	tenant, stackDomain string,
+) *models.TrustProviderGitLabJobModel {
 	stackDomain = strings.ToLower(stackDomain) // Force the stack/domain to be lowercase
 	stack := strings.Split(stackDomain, ".")[0]
 	model := &models.TrustProviderGitLabJobModel{
@@ -1597,18 +1986,26 @@ func convertGitLabJobDTOToModel(dto aembit.TrustProviderDTO, tenant, stackDomain
 		ProjectPath:   types.StringNull(),
 		NamespacePath: types.StringNull(),
 		RefPath:       types.StringNull(),
-		OIDCClientID:  types.StringValue(fmt.Sprintf("aembit:%s:%s:identity:gitlab_idtoken:%s", stack, tenant, dto.ExternalID)),
-		OIDCAudience:  types.StringValue(fmt.Sprintf("https://%s.id.%s", tenant, stackDomain)),
+		OIDCClientID: types.StringValue(
+			fmt.Sprintf("aembit:%s:%s:identity:gitlab_idtoken:%s", stack, tenant, dto.ExternalID),
+		),
+		OIDCAudience: types.StringValue(fmt.Sprintf("https://%s.id.%s", tenant, stackDomain)),
 	}
 
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("GitLabSubject")) {
 		model.Subject, model.Subjects = extractMatchRules(dto.MatchRules, "GitLabSubject")
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("GitLabProjectPath")) {
-		model.ProjectPath, model.ProjectPaths = extractMatchRules(dto.MatchRules, "GitLabProjectPath")
+		model.ProjectPath, model.ProjectPaths = extractMatchRules(
+			dto.MatchRules,
+			"GitLabProjectPath",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("GitLabNamespacePath")) {
-		model.NamespacePath, model.NamespacePaths = extractMatchRules(dto.MatchRules, "GitLabNamespacePath")
+		model.NamespacePath, model.NamespacePaths = extractMatchRules(
+			dto.MatchRules,
+			"GitLabNamespacePath",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("GitLabRefPath")) {
 		model.RefPath, model.RefPaths = extractMatchRules(dto.MatchRules, "GitLabRefPath")
@@ -1624,13 +2021,19 @@ func convertTerraformDTOToModel(dto aembit.TrustProviderDTO) *models.TrustProvid
 	}
 
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("TerraformOrganizationId")) {
-		model.OrganizationID, model.OrganizationIDs = extractMatchRules(dto.MatchRules, "TerraformOrganizationId")
+		model.OrganizationID, model.OrganizationIDs = extractMatchRules(
+			dto.MatchRules,
+			"TerraformOrganizationId",
+		)
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("TerraformProjectId")) {
 		model.ProjectID, model.ProjectIDs = extractMatchRules(dto.MatchRules, "TerraformProjectId")
 	}
 	if slices.ContainsFunc(dto.MatchRules, matchRuleAttributeFunc("TerraformWorkspaceId")) {
-		model.WorkspaceID, model.WorkspaceIDs = extractMatchRules(dto.MatchRules, "TerraformWorkspaceId")
+		model.WorkspaceID, model.WorkspaceIDs = extractMatchRules(
+			dto.MatchRules,
+			"TerraformWorkspaceId",
+		)
 	}
 	return model
 }
@@ -1654,10 +2057,13 @@ func matchRuleAttributeFunc(attributeName string) func(aembit.TrustProviderMatch
 }
 
 // extractMatchRules pulls out the match rules with the specified attribute name.
-func extractMatchRules(matchRules []aembit.TrustProviderMatchRuleDTO, attributeName string) (types.String, []types.String) {
-	var singleValue = types.StringNull()
+func extractMatchRules(
+	matchRules []aembit.TrustProviderMatchRuleDTO,
+	attributeName string,
+) (types.String, []types.String) {
+	singleValue := types.StringNull()
 	var multiValue []types.String = nil
-	var multipleMatchRules = matchRuleOccurrences(matchRules, attributeName) > 1
+	multipleMatchRules := matchRuleOccurrences(matchRules, attributeName) > 1
 
 	for _, rule := range matchRules {
 		if rule.Attribute == attributeName {

--- a/internal/provider/trust_provider_resource.go
+++ b/internal/provider/trust_provider_resource.go
@@ -1324,11 +1324,11 @@ func convertTerraformModelToDTO(model models.TrustProviderResourceModel, dto *ae
 // DTO to Model conversion methods.
 func convertTrustProviderDTOToModel(ctx context.Context, dto aembit.TrustProviderDTO, tenant, stackDomain string) models.TrustProviderResourceModel {
 	var model models.TrustProviderResourceModel
-	model.ID = types.StringValue(dto.EntityDTO.ExternalID)
-	model.Name = types.StringValue(dto.EntityDTO.Name)
-	model.Description = types.StringValue(dto.EntityDTO.Description)
-	model.IsActive = types.BoolValue(dto.EntityDTO.IsActive)
-	model.Tags = newTagsModel(ctx, dto.EntityDTO.Tags)
+	model.ID = types.StringValue(dto.ExternalID)
+	model.Name = types.StringValue(dto.Name)
+	model.Description = types.StringValue(dto.Description)
+	model.IsActive = types.BoolValue(dto.IsActive)
+	model.Tags = newTagsModel(ctx, dto.Tags)
 
 	switch dto.Provider {
 	case "AWSRole":
@@ -1655,9 +1655,9 @@ func matchRuleAttributeFunc(attributeName string) func(aembit.TrustProviderMatch
 
 // extractMatchRules pulls out the match rules with the specified attribute name.
 func extractMatchRules(matchRules []aembit.TrustProviderMatchRuleDTO, attributeName string) (types.String, []types.String) {
-	var singleValue types.String = types.StringNull()
+	var singleValue = types.StringNull()
 	var multiValue []types.String = nil
-	var multipleMatchRules bool = matchRuleOccurrences(matchRules, attributeName) > 1
+	var multipleMatchRules = matchRuleOccurrences(matchRules, attributeName) > 1
 
 	for _, rule := range matchRules {
 		if rule.Attribute == attributeName {

--- a/internal/provider/trust_provider_resource_test.go
+++ b/internal/provider/trust_provider_resource_test.go
@@ -11,13 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const trustProviderPathRole string = "aembit_trust_provider.aws_role"
-const trustProviderPathAzure string = "aembit_trust_provider.azure"
-const trustProviderGitLab1 string = "aembit_trust_provider.gitlab1"
-const trustProviderGitLab2 string = "aembit_trust_provider.gitlab2"
-const trustProviderGitLabMixed string = "aembit_trust_provider.gitlab_mixed"
-const gitLabOidcClientID string = "gitlab_job.oidc_client_id"
-const gitLabIdentityArnMatch string = ":identity:gitlab_idtoken:"
+const (
+	trustProviderPathRole    string = "aembit_trust_provider.aws_role"
+	trustProviderPathAzure   string = "aembit_trust_provider.azure"
+	trustProviderGitLab1     string = "aembit_trust_provider.gitlab1"
+	trustProviderGitLab2     string = "aembit_trust_provider.gitlab2"
+	trustProviderGitLabMixed string = "aembit_trust_provider.gitlab_mixed"
+	gitLabOidcClientID       string = "gitlab_job.oidc_client_id"
+	gitLabIdentityArnMatch   string = ":identity:gitlab_idtoken:"
+)
 
 func testDeleteTrustProvider(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -46,7 +48,11 @@ func TestAccTrustProviderResource_AzureMetadata(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderPathAzure, "name", "TF Acceptance Azure"),
+					resource.TestCheckResourceAttr(
+						trustProviderPathAzure,
+						"name",
+						"TF Acceptance Azure",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderPathAzure, "id"),
 					// Verify placeholder ID is set
@@ -54,7 +60,11 @@ func TestAccTrustProviderResource_AzureMetadata(t *testing.T) {
 				),
 			},
 			// Test Aembit API Removal causes re-create with non-empty plan
-			{Config: string(createFile), Check: testDeleteTrustProvider(trustProviderPathAzure), ExpectNonEmptyPlan: true},
+			{
+				Config:             string(createFile),
+				Check:              testDeleteTrustProvider(trustProviderPathAzure),
+				ExpectNonEmptyPlan: true,
+			},
 			// Recreate the resource from the first test step
 			{Config: string(createFile)},
 			// ImportState testing
@@ -64,7 +74,11 @@ func TestAccTrustProviderResource_AzureMetadata(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(trustProviderPathAzure, "name", "TF Acceptance Azure - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderPathAzure,
+						"name",
+						"TF Acceptance Azure - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -84,7 +98,11 @@ func TestAccTrustProviderResource_AwsRole(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderPathRole, "name", "TF Acceptance AWS Role"),
+					resource.TestCheckResourceAttr(
+						trustProviderPathRole,
+						"name",
+						"TF Acceptance AWS Role",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderPathRole, "id"),
 					// Verify placeholder ID is set
@@ -98,7 +116,11 @@ func TestAccTrustProviderResource_AwsRole(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(trustProviderPathRole, "name", "TF Acceptance AWS Role - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderPathRole,
+						"name",
+						"TF Acceptance AWS Role - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderPathRole, "id"),
 				),
@@ -120,7 +142,11 @@ func TestAccTrustProviderResource_AwsMetadata(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr("aembit_trust_provider.aws", "name", "TF Acceptance AWS"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.aws",
+						"name",
+						"TF Acceptance AWS",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.aws", "id"),
 					// Verify placeholder ID is set
@@ -134,7 +160,11 @@ func TestAccTrustProviderResource_AwsMetadata(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_trust_provider.aws", "name", "TF Acceptance AWS - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.aws",
+						"name",
+						"TF Acceptance AWS - Modified",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -154,7 +184,11 @@ func TestAccTrustProviderResource_GcpIdentity(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr("aembit_trust_provider.gcp", "name", "TF Acceptance GCP Identity"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.gcp",
+						"name",
+						"TF Acceptance GCP Identity",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.gcp", "id"),
 					// Verify placeholder ID is set
@@ -168,7 +202,11 @@ func TestAccTrustProviderResource_GcpIdentity(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_trust_provider.gcp", "name", "TF Acceptance GCP Identity - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.gcp",
+						"name",
+						"TF Acceptance GCP Identity - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.gcp", "id"),
 				),
@@ -190,7 +228,11 @@ func TestAccTrustProviderResource_GitHubAction(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr("aembit_trust_provider.github", "name", "TF Acceptance GitHub Action"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.github",
+						"name",
+						"TF Acceptance GitHub Action",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.github", "id"),
 					// Verify placeholder ID is set
@@ -198,13 +240,21 @@ func TestAccTrustProviderResource_GitHubAction(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_trust_provider.github", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "aembit_trust_provider.github",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_trust_provider.github", "name", "TF Acceptance GitHub Action - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.github",
+						"name",
+						"TF Acceptance GitHub Action - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.github", "id"),
 				),
@@ -226,23 +276,67 @@ func TestAccTrustProviderResource_GitLabJob(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderGitLab1, "name", "TF Acceptance GitLab Job1"),
-					resource.TestCheckResourceAttr(trustProviderGitLab2, "name", "TF Acceptance GitLab Job2"),
-					resource.TestCheckResourceAttr(trustProviderGitLabMixed, "name", "TF Acceptance GitLab Mixed"),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab1,
+						"name",
+						"TF Acceptance GitLab Job1",
+					),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab2,
+						"name",
+						"TF Acceptance GitLab Job2",
+					),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLabMixed,
+						"name",
+						"TF Acceptance GitLab Mixed",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderGitLab1, "id"),
 					resource.TestCheckResourceAttrSet(trustProviderGitLab2, "id"),
 					resource.TestCheckResourceAttrSet(trustProviderGitLabMixed, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttr(trustProviderGitLab1, "gitlab_job.oidc_endpoint", "https://gitlab.com"),
-					resource.TestCheckResourceAttr(trustProviderGitLab2, "gitlab_job.oidc_endpoint", "https://gitlab.com"),
-					resource.TestCheckResourceAttr(trustProviderGitLab1, "gitlab_job.namespace_path", "namespace_path"),
-					resource.TestCheckResourceAttr(trustProviderGitLab2, "gitlab_job.namespace_paths.0", "namespace_path1"),
-					resource.TestCheckResourceAttr(trustProviderGitLab2, "gitlab_job.namespace_paths.1", "namespace_path2"),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab1,
+						"gitlab_job.oidc_endpoint",
+						"https://gitlab.com",
+					),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab2,
+						"gitlab_job.oidc_endpoint",
+						"https://gitlab.com",
+					),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab1,
+						"gitlab_job.namespace_path",
+						"namespace_path",
+					),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab2,
+						"gitlab_job.namespace_paths.0",
+						"namespace_path1",
+					),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab2,
+						"gitlab_job.namespace_paths.1",
+						"namespace_path2",
+					),
 					// Check read-only values
-					checkValidClientID(trustProviderGitLab1, gitLabOidcClientID, gitLabIdentityArnMatch),
-					checkValidClientID(trustProviderGitLab2, gitLabOidcClientID, gitLabIdentityArnMatch),
-					checkValidClientID(trustProviderGitLabMixed, gitLabOidcClientID, gitLabIdentityArnMatch),
+					checkValidClientID(
+						trustProviderGitLab1,
+						gitLabOidcClientID,
+						gitLabIdentityArnMatch,
+					),
+					checkValidClientID(
+						trustProviderGitLab2,
+						gitLabOidcClientID,
+						gitLabIdentityArnMatch,
+					),
+					checkValidClientID(
+						trustProviderGitLabMixed,
+						gitLabOidcClientID,
+						gitLabIdentityArnMatch,
+					),
 				),
 			},
 			// ImportState testing
@@ -252,7 +346,11 @@ func TestAccTrustProviderResource_GitLabJob(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(trustProviderGitLab1, "name", "TF Acceptance GitLab Job - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderGitLab1,
+						"name",
+						"TF Acceptance GitLab Job - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderGitLab1, "id"),
 				),
@@ -263,7 +361,9 @@ func TestAccTrustProviderResource_GitLabJob(t *testing.T) {
 }
 
 func TestAccTrustProviderResource_GitLabJob_Validation(t *testing.T) {
-	invalidNameFile, _ := os.ReadFile("../../tests/trust/gitlab/TestAccTrustProviderResource.tfinvalid")
+	invalidNameFile, _ := os.ReadFile(
+		"../../tests/trust/gitlab/TestAccTrustProviderResource.tfinvalid",
+	)
 
 	regexChecks := []string{
 		// Protect against empty strings
@@ -286,7 +386,13 @@ func TestAccTrustProviderResource_GitLabJob_Validation(t *testing.T) {
 	}
 	validationChecks := []resource.TestStep{}
 	for _, check := range regexChecks {
-		validationChecks = append(validationChecks, resource.TestStep{Config: string(invalidNameFile), ExpectError: regexp.MustCompile(check)})
+		validationChecks = append(
+			validationChecks,
+			resource.TestStep{
+				Config:      string(invalidNameFile),
+				ExpectError: regexp.MustCompile(check),
+			},
+		)
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -307,29 +413,65 @@ func TestAccTrustProviderResource_Kerberos(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", "name", "TF Acceptance Kerberos"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						"name",
+						"TF Acceptance Kerberos",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.kerberos", "id"),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.kerberos", "id"),
 					// Verify Tags.
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", tagsCount, "2"),
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", tagsColor, "blue"),
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", tagsDay, "Sunday"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						tagsColor,
+						"blue",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						tagsDay,
+						"Sunday",
+					),
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_trust_provider.kerberos", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "aembit_trust_provider.kerberos",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", "name", "TF Acceptance Kerberos - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						"name",
+						"TF Acceptance Kerberos - Modified",
+					),
 					// Verify Tags.
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", tagsCount, "2"),
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", tagsColor, "orange"),
-					resource.TestCheckResourceAttr("aembit_trust_provider.kerberos", tagsDay, "Tuesday"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						tagsCount,
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						tagsColor,
+						"orange",
+					),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.kerberos",
+						tagsDay,
+						"Tuesday",
+					),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -353,7 +495,11 @@ func TestAccTrustProviderResource_KubernetesServiceAccount(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderKubernetes, "name", "TF Acceptance Kubernetes"),
+					resource.TestCheckResourceAttr(
+						trustProviderKubernetes,
+						"name",
+						"TF Acceptance Kubernetes",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderKubernetes, "id"),
 					// Verify placeholder ID is set
@@ -363,13 +509,21 @@ func TestAccTrustProviderResource_KubernetesServiceAccount(t *testing.T) {
 					resource.TestCheckResourceAttr(trustProviderKubernetes, tagsColor, "blue"),
 					resource.TestCheckResourceAttr(trustProviderKubernetes, tagsDay, "Sunday"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderKubernetesKey, "name", "TF Acceptance Kubernetes Key"),
+					resource.TestCheckResourceAttr(
+						trustProviderKubernetesKey,
+						"name",
+						"TF Acceptance Kubernetes Key",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderKubernetesKey, "id"),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(trustProviderKubernetesKey, "id"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderKubernetesJWKS, "name", "TF Acceptance Kubernetes JWKS"),
+					resource.TestCheckResourceAttr(
+						trustProviderKubernetesJWKS,
+						"name",
+						"TF Acceptance Kubernetes JWKS",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderKubernetesJWKS, "id"),
 					// Verify placeholder ID is set
@@ -383,19 +537,31 @@ func TestAccTrustProviderResource_KubernetesServiceAccount(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(trustProviderKubernetes, "name", "TF Acceptance Kubernetes - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderKubernetes,
+						"name",
+						"TF Acceptance Kubernetes - Modified",
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(trustProviderKubernetes, tagsCount, "2"),
 					resource.TestCheckResourceAttr(trustProviderKubernetes, tagsColor, "orange"),
 					resource.TestCheckResourceAttr(trustProviderKubernetes, tagsDay, "Tuesday"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderKubernetesKey, "name", "TF Acceptance Kubernetes Key - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderKubernetesKey,
+						"name",
+						"TF Acceptance Kubernetes Key - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderKubernetesKey, "id"),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(trustProviderKubernetesKey, "id"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderKubernetesJWKS, "name", "TF Acceptance Kubernetes JWKS - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderKubernetesJWKS,
+						"name",
+						"TF Acceptance Kubernetes JWKS - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderKubernetesJWKS, "id"),
 					// Verify placeholder ID is set
@@ -419,7 +585,11 @@ func TestAccTrustProviderResource_TerraformWorkspace(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr("aembit_trust_provider.terraform", "name", "TF Acceptance Terraform Workspace"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.terraform",
+						"name",
+						"TF Acceptance Terraform Workspace",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.terraform", "id"),
 					// Verify placeholder ID is set
@@ -427,13 +597,21 @@ func TestAccTrustProviderResource_TerraformWorkspace(t *testing.T) {
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_trust_provider.terraform", ImportState: true, ImportStateVerify: true},
+			{
+				ResourceName:      "aembit_trust_provider.terraform",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr("aembit_trust_provider.terraform", "name", "TF Acceptance Terraform Workspace - Modified"),
+					resource.TestCheckResourceAttr(
+						"aembit_trust_provider.terraform",
+						"name",
+						"TF Acceptance Terraform Workspace - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("aembit_trust_provider.terraform", "id"),
 				),
@@ -445,7 +623,9 @@ func TestAccTrustProviderResource_TerraformWorkspace(t *testing.T) {
 
 func TestAccTrustProviderResource_OidcIdToken(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/trust/oidc-id-token/TestAccTrustProviderResource.tf")
-	modifyFile, _ := os.ReadFile("../../tests/trust/oidc-id-token/TestAccTrustProviderResource.tfmod")
+	modifyFile, _ := os.ReadFile(
+		"../../tests/trust/oidc-id-token/TestAccTrustProviderResource.tfmod",
+	)
 
 	const trustProviderOidcidToken = "aembit_trust_provider.oidcidtoken"
 	const trustProviderOidcidTokenKey = "aembit_trust_provider.oidcidtoken_key"
@@ -459,7 +639,11 @@ func TestAccTrustProviderResource_OidcIdToken(t *testing.T) {
 				Config: string(createFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderOidcidToken, "name", "TF Acceptance OIDC ID Token"),
+					resource.TestCheckResourceAttr(
+						trustProviderOidcidToken,
+						"name",
+						"TF Acceptance OIDC ID Token",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderOidcidToken, "id"),
 					// Verify placeholder ID is set
@@ -469,13 +653,21 @@ func TestAccTrustProviderResource_OidcIdToken(t *testing.T) {
 					resource.TestCheckResourceAttr(trustProviderOidcidToken, tagsColor, "blue"),
 					resource.TestCheckResourceAttr(trustProviderOidcidToken, tagsDay, "Sunday"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderOidcidTokenKey, "name", "TF Acceptance OIDC ID Token Key"),
+					resource.TestCheckResourceAttr(
+						trustProviderOidcidTokenKey,
+						"name",
+						"TF Acceptance OIDC ID Token Key",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderOidcidTokenKey, "id"),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(trustProviderOidcidTokenKey, "id"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderOidcidTokenJWKS, "name", "TF Acceptance OIDC ID Token JWKS"),
+					resource.TestCheckResourceAttr(
+						trustProviderOidcidTokenJWKS,
+						"name",
+						"TF Acceptance OIDC ID Token JWKS",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderOidcidTokenJWKS, "id"),
 					// Verify placeholder ID is set
@@ -489,19 +681,31 @@ func TestAccTrustProviderResource_OidcIdToken(t *testing.T) {
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
-					resource.TestCheckResourceAttr(trustProviderOidcidToken, "name", "TF Acceptance OIDC ID Token - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderOidcidToken,
+						"name",
+						"TF Acceptance OIDC ID Token - Modified",
+					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(trustProviderOidcidToken, tagsCount, "2"),
 					resource.TestCheckResourceAttr(trustProviderOidcidToken, tagsColor, "blue"),
 					resource.TestCheckResourceAttr(trustProviderOidcidToken, tagsDay, "Sunday"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderOidcidTokenKey, "name", "TF Acceptance OIDC ID Token Key - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderOidcidTokenKey,
+						"name",
+						"TF Acceptance OIDC ID Token Key - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderOidcidTokenKey, "id"),
 					// Verify placeholder ID is set
 					resource.TestCheckResourceAttrSet(trustProviderOidcidTokenKey, "id"),
 					// Verify Trust Provider Name
-					resource.TestCheckResourceAttr(trustProviderOidcidTokenJWKS, "name", "TF Acceptance OIDC ID Token JWKS - Modified"),
+					resource.TestCheckResourceAttr(
+						trustProviderOidcidTokenJWKS,
+						"name",
+						"TF Acceptance OIDC ID Token JWKS - Modified",
+					),
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet(trustProviderOidcidTokenJWKS, "id"),
 					// Verify placeholder ID is set
@@ -514,7 +718,9 @@ func TestAccTrustProviderResource_OidcIdToken(t *testing.T) {
 }
 
 func TestAccTrustProviderResource_OidcIdToken_MissingRequiredRSAField(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/trust/oidc-id-token/TestAccTrustProviderResource_MissingRequiredRSAField.tf")
+	createFile, _ := os.ReadFile(
+		"../../tests/trust/oidc-id-token/TestAccTrustProviderResource_MissingRequiredRSAField.tf",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -528,7 +734,9 @@ func TestAccTrustProviderResource_OidcIdToken_MissingRequiredRSAField(t *testing
 }
 
 func TestAccTrustProviderResource_OidcIdToken_MissingRequiredECDSAField(t *testing.T) {
-	createFile, _ := os.ReadFile("../../tests/trust/oidc-id-token/TestAccTrustProviderResource_MissingRequiredEDSAField.tf")
+	createFile, _ := os.ReadFile(
+		"../../tests/trust/oidc-id-token/TestAccTrustProviderResource_MissingRequiredEDSAField.tf",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/trust_provider_resource_test.go
+++ b/internal/provider/trust_provider_resource_test.go
@@ -12,13 +12,18 @@ import (
 )
 
 const (
-	trustProviderPathRole    string = "aembit_trust_provider.aws_role"
-	trustProviderPathAzure   string = "aembit_trust_provider.azure"
-	trustProviderGitLab1     string = "aembit_trust_provider.gitlab1"
-	trustProviderGitLab2     string = "aembit_trust_provider.gitlab2"
-	trustProviderGitLabMixed string = "aembit_trust_provider.gitlab_mixed"
-	gitLabOidcClientID       string = "gitlab_job.oidc_client_id"
-	gitLabIdentityArnMatch   string = ":identity:gitlab_idtoken:"
+	trustProviderPathRole          = "aembit_trust_provider.aws_role"
+	trustProviderPathAzure         = "aembit_trust_provider.azure"
+	trustProviderGitLab1           = "aembit_trust_provider.gitlab1"
+	trustProviderGitLab2           = "aembit_trust_provider.gitlab2"
+	trustProviderGitLabMixed       = "aembit_trust_provider.gitlab_mixed"
+	gitLabOidcClientID             = "gitlab_job.oidc_client_id"
+	gitLabIdentityArnMatch         = ":identity:gitlab_idtoken:"
+	trustProviderAwsPath           = "aembit_trust_provider.aws"
+	trustProviderGcp               = "aembit_trust_provider.gcp"
+	trustProviderGitHub            = "aembit_trust_provider.github"
+	trustProviderKerberos          = "aembit_trust_provider.kerberos"
+	trustProviderTerraformResource = "aembit_trust_provider.terraform"
 )
 
 func testDeleteTrustProvider(resourceName string) resource.TestCheckFunc {
@@ -143,25 +148,25 @@ func TestAccTrustProviderResource_AwsMetadata(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.aws",
+						trustProviderAwsPath,
 						"name",
 						"TF Acceptance AWS",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.aws", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderAwsPath, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.aws", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderAwsPath, "id"),
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_trust_provider.aws", ImportState: true, ImportStateVerify: true},
+			{ResourceName: trustProviderAwsPath, ImportState: true, ImportStateVerify: true},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.aws",
+						trustProviderAwsPath,
 						"name",
 						"TF Acceptance AWS - Modified",
 					),
@@ -185,30 +190,30 @@ func TestAccTrustProviderResource_GcpIdentity(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.gcp",
+						trustProviderGcp,
 						"name",
 						"TF Acceptance GCP Identity",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.gcp", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderGcp, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.gcp", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderGcp, "id"),
 				),
 			},
 			// ImportState testing
-			{ResourceName: "aembit_trust_provider.gcp", ImportState: true, ImportStateVerify: true},
+			{ResourceName: trustProviderGcp, ImportState: true, ImportStateVerify: true},
 			// Update and Read testing
 			{
 				Config: string(modifyFile),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.gcp",
+						trustProviderGcp,
 						"name",
 						"TF Acceptance GCP Identity - Modified",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.gcp", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderGcp, "id"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -229,19 +234,19 @@ func TestAccTrustProviderResource_GitHubAction(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.github",
+						trustProviderGitHub,
 						"name",
 						"TF Acceptance GitHub Action",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.github", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderGitHub, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.github", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderGitHub, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_trust_provider.github",
+				ResourceName:      trustProviderGitHub,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -251,12 +256,12 @@ func TestAccTrustProviderResource_GitHubAction(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.github",
+						trustProviderGitHub,
 						"name",
 						"TF Acceptance GitHub Action - Modified",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.github", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderGitHub, "id"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -414,27 +419,27 @@ func TestAccTrustProviderResource_Kerberos(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						"name",
 						"TF Acceptance Kerberos",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.kerberos", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderKerberos, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.kerberos", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderKerberos, "id"),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						tagsCount,
 						"2",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						tagsColor,
 						"blue",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						tagsDay,
 						"Sunday",
 					),
@@ -442,7 +447,7 @@ func TestAccTrustProviderResource_Kerberos(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_trust_provider.kerberos",
+				ResourceName:      trustProviderKerberos,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -452,23 +457,23 @@ func TestAccTrustProviderResource_Kerberos(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						"name",
 						"TF Acceptance Kerberos - Modified",
 					),
 					// Verify Tags.
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						tagsCount,
 						"2",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						tagsColor,
 						"orange",
 					),
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.kerberos",
+						trustProviderKerberos,
 						tagsDay,
 						"Tuesday",
 					),
@@ -586,19 +591,19 @@ func TestAccTrustProviderResource_TerraformWorkspace(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Trust Provider Name
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.terraform",
+						trustProviderTerraformResource,
 						"name",
 						"TF Acceptance Terraform Workspace",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.terraform", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderTerraformResource, "id"),
 					// Verify placeholder ID is set
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.terraform", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderTerraformResource, "id"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "aembit_trust_provider.terraform",
+				ResourceName:      trustProviderTerraformResource,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -608,12 +613,12 @@ func TestAccTrustProviderResource_TerraformWorkspace(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify Name updated
 					resource.TestCheckResourceAttr(
-						"aembit_trust_provider.terraform",
+						trustProviderTerraformResource,
 						"name",
 						"TF Acceptance Terraform Workspace - Modified",
 					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet("aembit_trust_provider.terraform", "id"),
+					resource.TestCheckResourceAttrSet(trustProviderTerraformResource, "id"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/trust_providers_data_source.go
+++ b/internal/provider/trust_providers_data_source.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"terraform-provider-aembit/internal/provider/models"
 
 	"aembit.io/aembit"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -27,17 +27,29 @@ type trustProvidersDataSource struct {
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *trustProvidersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *trustProvidersDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
 	d.client = datasourceConfigure(req, resp)
 }
 
 // Metadata returns the data source type name.
-func (d *trustProvidersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *trustProvidersDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_trust_providers"
 }
 
 // Schema defines the schema for the resource.
-func (d *trustProvidersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *trustProvidersDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
 	resp.Schema = schema.Schema{
 		Description: "Manages an trust provider.",
 		Attributes: map[string]schema.Attribute{
@@ -580,7 +592,11 @@ func (d *trustProvidersDataSource) Schema(_ context.Context, _ datasource.Schema
 }
 
 // Read refreshes the Terraform state with the latest data.
-func (d *trustProvidersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *trustProvidersDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state models.TrustProvidersDataSourceModel
 
 	trustProviders, err := d.client.GetTrustProviders(nil)
@@ -594,7 +610,12 @@ func (d *trustProvidersDataSource) Read(ctx context.Context, req datasource.Read
 
 	// Map response body to model
 	for _, trustProvider := range trustProviders {
-		trustProviderState := convertTrustProviderDTOToModel(ctx, trustProvider, d.client.Tenant, d.client.StackDomain)
+		trustProviderState := convertTrustProviderDTOToModel(
+			ctx,
+			trustProvider,
+			d.client.Tenant,
+			d.client.StackDomain,
+		)
 		state.TrustProviders = append(state.TrustProviders, trustProviderState)
 	}
 

--- a/internal/provider/trust_providers_data_source_test.go
+++ b/internal/provider/trust_providers_data_source_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testTrustProvidersDataSource string = "data.aembit_trust_providers.test"
-const testTrustProviderResource string = "aembit_trust_provider.kubernetes_key"
+const (
+	testTrustProvidersDataSource string = "data.aembit_trust_providers.test"
+	testTrustProviderResource    string = "aembit_trust_provider.kubernetes_key"
+)
 
 func testFindTrustProvider(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -30,7 +32,11 @@ func testFindTrustProvider(resourceName string) resource.TestCheckFunc {
 
 func TestAccTrustProvidersDataSource(t *testing.T) {
 	createFile, _ := os.ReadFile("../../tests/trust/data/TestAccTrustProvidersDataSource.tf")
-	createFileConfig, _, _ := randomizeFileConfigs(string(createFile), "", "TF Acceptance Kubernetes")
+	createFileConfig, _, _ := randomizeFileConfigs(
+		string(createFile),
+		"",
+		"TF Acceptance Kubernetes",
+	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -40,9 +46,15 @@ func TestAccTrustProvidersDataSource(t *testing.T) {
 				Config: createFileConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify non-zero number of Trust Providers returned
-					resource.TestCheckResourceAttrSet(testTrustProvidersDataSource, "trust_providers.#"),
+					resource.TestCheckResourceAttrSet(
+						testTrustProvidersDataSource,
+						"trust_providers.#",
+					),
 					// Verify dynamic values have any value set in the state.
-					resource.TestCheckResourceAttrSet(testTrustProvidersDataSource, "trust_providers.0.id"),
+					resource.TestCheckResourceAttrSet(
+						testTrustProvidersDataSource,
+						"trust_providers.0.id",
+					),
 					// Find newly created entry
 					testFindTrustProvider(testTrustProviderResource),
 				),

--- a/internal/provider/validators/credential_provider_mapping_validator.go
+++ b/internal/provider/validators/credential_provider_mapping_validator.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-aembit/internal/provider/models"
-
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"terraform-provider-aembit/internal/provider/models"
 )
 
 type CredentialProviderMappingValidator struct{}
@@ -19,7 +18,11 @@ func (v CredentialProviderMappingValidator) MarkdownDescription(ctx context.Cont
 	return v.Description(ctx)
 }
 
-func (v CredentialProviderMappingValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+func (v CredentialProviderMappingValidator) ValidateSet(
+	ctx context.Context,
+	req validator.SetRequest,
+	resp *validator.SetResponse,
+) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/provider/validators/oidc_endpoint_validator.go
+++ b/internal/provider/validators/oidc_endpoint_validator.go
@@ -23,7 +23,11 @@ func (v oidcEndpointValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v oidcEndpointValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+func (v oidcEndpointValidator) ValidateString(
+	ctx context.Context,
+	req validator.StringRequest,
+	resp *validator.StringResponse,
+) {
 	if strings.Contains(req.ConfigValue.ValueString(), "/.well-known/openid-configuration") {
 		resp.Diagnostics.AddError(
 			"Invalid OIDC Endpoint",

--- a/internal/provider/validators/regex_test.go
+++ b/internal/provider/validators/regex_test.go
@@ -224,3 +224,78 @@ func TestRegex_Hostname_Invalid(t *testing.T) {
 		})
 	}
 }
+
+func TestRegex_SafeWildcardHostname_Valid(t *testing.T) {
+	validInputs := []string{
+		"example.com",
+		"sub.domain.com",
+		"my-site.co.uk",
+		"localhost",
+		"example.travel",
+		"aembit.io",
+		"host",
+		"test.com",
+		"*.amazonaws.com",
+		"bucket.*.amazonaws.com",
+		"bucket.*.microsoft.com",
+		"wild*card.amazonaws.com",
+	}
+	for _, input := range validInputs {
+		t.Run(input, func(t *testing.T) {
+			if !StructuralHostRegex.MatchString(input) {
+				t.Errorf("Expected valid structural hostname, but got invalid: %s", input)
+			}
+		})
+	}
+}
+
+func TestRegex_SafeWildcardHostname_Invalid(t *testing.T) {
+	validInputs := []string{
+		"-invalid.com",
+		"example..com",
+		"example_com",
+		".example.com",
+		"example.com-",
+		"google.*",
+		"google.n*t",
+		"*.com",
+		"goo*gle.com",
+		"", // Empty string
+	}
+	for _, input := range validInputs {
+		t.Run(input, func(t *testing.T) {
+			if StructuralHostRegex.MatchString(input) {
+				t.Errorf("Expected invalid structural hostname, but got valid: %s", input)
+			}
+		})
+	}
+}
+
+func TestRegex_IPHost_Valid(t *testing.T) {
+	validInputs := []string{
+		"192.168.1.1",
+		"10.0.0.1",
+		"172.16.0.1",
+	}
+	for _, input := range validInputs {
+		t.Run(input, func(t *testing.T) {
+			if !HostIPRegex.MatchString(input) {
+				t.Errorf("Expected valid IP host, but got invalid: %s", input)
+			}
+		})
+	}
+}
+
+func TestRegex_IPHost_Invalid(t *testing.T) {
+	validInputs := []string{
+		"192.*.86.1", // IP with wildcard
+		"",           // Empty string
+	}
+	for _, input := range validInputs {
+		t.Run(input, func(t *testing.T) {
+			if HostIPRegex.MatchString(input) {
+				t.Errorf("Expected invalid IP host, but got valid: %s", input)
+			}
+		})
+	}
+}

--- a/internal/provider/validators/regex_test.go
+++ b/internal/provider/validators/regex_test.go
@@ -273,9 +273,9 @@ func TestRegex_SafeWildcardHostname_Invalid(t *testing.T) {
 
 func TestRegex_IPHost_Valid(t *testing.T) {
 	validInputs := []string{
-		"192.168.1.1",
-		"10.0.0.1",
-		"172.16.0.1",
+		"192.168.1.1", // NOSONAR
+		"10.0.0.1",    // NOSONAR
+		"172.16.0.1",  // NOSONAR
 	}
 	for _, input := range validInputs {
 		t.Run(input, func(t *testing.T) {

--- a/internal/provider/validators/string_validators.go
+++ b/internal/provider/validators/string_validators.go
@@ -7,24 +7,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-var UUIDRegex = regexp.MustCompile(`^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$`)
-var EmailRegex = regexp.MustCompile(`^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$`)
-var SnowflakeAccountRegex = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
-var SnowflakeUserNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_@]+$`)
-var UrlSchemeRegex = regexp.MustCompile(`^http(s)?:\/\/.*$`)
-var SecureURLRegex = regexp.MustCompile(`^https:\/\/[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,}(\/\S*)?$`)
-var HostNameRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)$`)
-var HostIPRegex = regexp.MustCompile(`^((?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$`)
-var StructuralHostRegex = regexp.MustCompile(`^(?:(?:[a-zA-Z\d*](?:[a-zA-Z\d*-]*[a-zA-Z\d*])?\.)*(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)\.(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)|[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)$`)
-var S3BucketRegionRegex = regexp.MustCompile(`^[a-z\-\d]+$`)
-var S3BucketNameRegex = regexp.MustCompile(`^[a-z\d][a-z\-\.\d]{1,61}?[a-z\d]$`)
-var S3PathPrefixRegex = regexp.MustCompile(`^[^\\\{\}\^\%` + "`" + `""'~#\[\]\>\<\|\x80-\xff]*$`)
-var GCSBucketNameSimpleRegex = regexp.MustCompile(`^[a-z0-9-_]{3,63}$`)
-var GCSBucketNameWithPeriodRegex = regexp.MustCompile(`^[a-z0-9-\._]{3,222}$`)
-var GCSPathPrefixRegex = regexp.MustCompile(`^[^#\[\]*?:\"<>|]{0,256}$`)
-var HecHostPortRegex = regexp.MustCompile(`^([a-zA-Z0-9.-]+):(\d{2,5})$`)
-var AuthenticationTokenRegex = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
-var ApiKeyRegex = regexp.MustCompile(`^[a-f0-9]{32}$`)
+var (
+	UUIDRegex = regexp.MustCompile(
+		`^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$`,
+	)
+	EmailRegex = regexp.MustCompile(
+		`^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$`,
+	)
+	SnowflakeAccountRegex  = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+	SnowflakeUserNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_@]+$`)
+	UrlSchemeRegex         = regexp.MustCompile(`^http(s)?:\/\/.*$`)
+	SecureURLRegex         = regexp.MustCompile(
+		`^https:\/\/[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,}(\/\S*)?$`,
+	)
+	HostNameRegex = regexp.MustCompile(
+		`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)$`,
+	)
+	HostIPRegex = regexp.MustCompile(
+		`^((?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$`,
+	)
+	StructuralHostRegex = regexp.MustCompile(
+		`^(?:(?:[a-zA-Z\d*](?:[a-zA-Z\d*-]*[a-zA-Z\d*])?\.)*(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)\.(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)|[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)$`,
+	)
+	S3BucketRegionRegex = regexp.MustCompile(`^[a-z\-\d]+$`)
+	S3BucketNameRegex   = regexp.MustCompile(`^[a-z\d][a-z\-\.\d]{1,61}?[a-z\d]$`)
+	S3PathPrefixRegex   = regexp.MustCompile(
+		`^[^\\\{\}\^\%` + "`" + `""'~#\[\]\>\<\|\x80-\xff]*$`,
+	)
+	GCSBucketNameSimpleRegex     = regexp.MustCompile(`^[a-z0-9-_]{3,63}$`)
+	GCSBucketNameWithPeriodRegex = regexp.MustCompile(`^[a-z0-9-\._]{3,222}$`)
+	GCSPathPrefixRegex           = regexp.MustCompile(`^[^#\[\]*?:\"<>|]{0,256}$`)
+	HecHostPortRegex             = regexp.MustCompile(`^([a-zA-Z0-9.-]+):(\d{2,5})$`)
+	AuthenticationTokenRegex     = regexp.MustCompile(
+		`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`,
+	)
+	ApiKeyRegex = regexp.MustCompile(`^[a-f0-9]{32}$`)
+)
 
 func NameLengthValidation() validator.String {
 	return stringvalidator.LengthBetween(1, 128)
@@ -39,11 +57,17 @@ func EmailValidation() validator.String {
 }
 
 func SnowflakeAccountValidation() validator.String {
-	return stringvalidator.RegexMatches(SnowflakeAccountRegex, "must be a valid Snowflake Account ID")
+	return stringvalidator.RegexMatches(
+		SnowflakeAccountRegex,
+		"must be a valid Snowflake Account ID",
+	)
 }
 
 func SnowflakeUserNameValidation() validator.String {
-	return stringvalidator.RegexMatches(SnowflakeUserNameRegex, "must be a valid Snowflake Username")
+	return stringvalidator.RegexMatches(
+		SnowflakeUserNameRegex,
+		"must be a valid Snowflake Username",
+	)
 }
 
 func UrlSchemeValidation() validator.String {
@@ -94,7 +118,10 @@ func GCSBucketNameSimpleValidation() validator.String {
 }
 
 func GCSBucketNameWithPeriodValidation() validator.String {
-	return stringvalidator.RegexMatches(GCSBucketNameWithPeriodRegex, "must be a valid GCS Bucket name")
+	return stringvalidator.RegexMatches(
+		GCSBucketNameWithPeriodRegex,
+		"must be a valid GCS Bucket name",
+	)
 }
 
 func GCSPathPrefixValidation() validator.String {
@@ -110,7 +137,10 @@ func HecHostPortValidation() validator.String {
 }
 
 func AuthenticationTokenValidation() validator.String {
-	return stringvalidator.RegexMatches(AuthenticationTokenRegex, "must be a valid authentication token")
+	return stringvalidator.RegexMatches(
+		AuthenticationTokenRegex,
+		"must be a valid authentication token",
+	)
 }
 
 func CrowdstrikeApiKeyValidation() validator.String {

--- a/internal/provider/validators/string_validators.go
+++ b/internal/provider/validators/string_validators.go
@@ -14,6 +14,8 @@ var SnowflakeUserNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_@]+$`)
 var UrlSchemeRegex = regexp.MustCompile(`^http(s)?:\/\/.*$`)
 var SecureURLRegex = regexp.MustCompile(`^https:\/\/[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,}(\/\S*)?$`)
 var HostNameRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)$`)
+var HostIPRegex = regexp.MustCompile(`^((?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$`)
+var StructuralHostRegex = regexp.MustCompile(`^(?:(?:[a-zA-Z\d*](?:[a-zA-Z\d*-]*[a-zA-Z\d*])?\.)*(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)\.(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)|[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?)$`)
 var S3BucketRegionRegex = regexp.MustCompile(`^[a-z\-\d]+$`)
 var S3BucketNameRegex = regexp.MustCompile(`^[a-z\d][a-z\-\.\d]{1,61}?[a-z\d]$`)
 var S3PathPrefixRegex = regexp.MustCompile(`^[^\\\{\}\^\%` + "`" + `""'~#\[\]\>\<\|\x80-\xff]*$`)
@@ -54,6 +56,13 @@ func SecureURLValidation() validator.String {
 
 func HostValidation() validator.String {
 	return stringvalidator.RegexMatches(HostNameRegex, "must be a valid hostname")
+}
+
+func SafeWildcardHostNameValidation() validator.String {
+	return stringvalidator.Any(
+		stringvalidator.RegexMatches(HostIPRegex, "must be a valid hostname or IP address"),
+		stringvalidator.RegexMatches(StructuralHostRegex, "must be a valid hostname or IP address"),
+	)
 }
 
 func S3BucketRegionLengthValidation() validator.String {

--- a/main.go
+++ b/main.go
@@ -8,9 +8,8 @@ import (
 	"flag"
 	"log"
 
-	"terraform-provider-aembit/internal/provider"
-
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"terraform-provider-aembit/internal/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -23,19 +22,22 @@ import (
 // can be customized.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-var (
-	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary.
-	version string = "dev"
+// these will be set by the goreleaser configuration
+// to appropriate values for the compiled binary.
+var version string = "dev"
 
-	// goreleaser can pass other information to the main package, such as the specific commit
-	// https://goreleaser.com/cookbooks/using-main.version/
-)
+// goreleaser can pass other information to the main package, such as the specific commit
+// https://goreleaser.com/cookbooks/using-main.version/
 
 func main() {
 	var debug bool
 
-	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.BoolVar(
+		&debug,
+		"debug",
+		false,
+		"set to true to run the provider with support for debuggers like delve",
+	)
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
@@ -44,7 +46,6 @@ func main() {
 	}
 
 	err := providerserver.Serve(context.Background(), provider.New(version), opts)
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/tests/server/TestAccServerWorkloadResource.tf
+++ b/tests/server/TestAccServerWorkloadResource.tf
@@ -29,3 +29,27 @@ resource "aembit_server_workload" "test" {
         day   = "Sunday"
     }
 }
+
+resource "aembit_server_workload" "test_wildcard" {
+	name = "Unit Test 1 Wildcard"
+    description = "Description"
+    is_active = false
+	service_endpoint = {
+		host = "*.testhost.com"
+		port = 443
+        tls = true
+		app_protocol = "HTTP"
+		transport_protocol = "TCP"
+		requested_port = 443
+        requested_tls = true
+		tls_verification = "full"
+		authentication_config = {
+			"method" = "HTTP Authentication"
+			"scheme" = "Bearer"
+		}
+	}
+    tags = {
+        color = "blue"
+        day   = "Sunday"
+    }
+}

--- a/tests/server/TestAccServerWorkloadResource.tfmod
+++ b/tests/server/TestAccServerWorkloadResource.tfmod
@@ -25,3 +25,28 @@ resource "aembit_server_workload" "test" {
         day   = "Tuesday"
     }
 }
+
+resource "aembit_server_workload" "test_wildcard" {
+	name = "Unit Test 1 Wildcard - Modified"
+    description = "Description"
+    is_active = false
+	service_endpoint = {
+		host = "*.testhost2.com"
+		port = 443
+        tls = true
+		app_protocol = "HTTP"
+		transport_protocol = "TCP"
+		requested_port = 443
+        requested_tls = true
+		tls_verification = "full"
+		authentication_config = {
+			"method" = "HTTP Authentication"
+			"scheme" = "Bearer"
+		}
+	}
+    tags = {
+        color = "blue"
+        day   = "Sunday"
+    }
+}
+


### PR DESCRIPTION
Note: Most of the changes in this PR are noise due to needing to upgrade the go ci linter. The key change has to do with string validation in the `internal/provider/validators` folder.