### PR TITLE
BAC-6733: Content Security: Enforce range validation on timeout_ms and update test fixtures

### DIFF
--- a/internal/provider/content_security_resource.go
+++ b/internal/provider/content_security_resource.go
@@ -7,6 +7,7 @@ import (
 	"terraform-provider-aembit/internal/provider/validators"
 
 	"aembit.io/aembit"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -138,12 +139,18 @@ func (r *contentSecurityResource) Schema(
 						Optional:    true,
 						Computed:    true,
 						Default:     int64default.StaticInt64(5000),
+						Validators: []validator.Int64{
+							int64validator.Between(5000, 600000),
+						},
 					},
 					"max_retries": schema.Int64Attribute{
 						Description: "The maximum number of retry attempts for requests to the CrowdStrike Falcon AIDR service.",
 						Optional:    true,
 						Computed:    true,
 						Default:     int64default.StaticInt64(2),
+						Validators: []validator.Int64{
+							int64validator.Between(0, 10),
+						},
 					},
 				},
 			},

--- a/internal/provider/content_security_resource_test.go
+++ b/internal/provider/content_security_resource_test.go
@@ -65,7 +65,7 @@ func TestAccContentSecurityResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						testContentSecurityResource,
 						"crowdstrike_falcon_aidr.timeout_ms",
-						"3000",
+						"6000",
 					),
 					// Verify placeholder ID and resource_set_id are set
 					resource.TestCheckResourceAttrSet(testContentSecurityResource, "id"),

--- a/tests/content_security/crowdstrike_aidr/TestAccContentSecurityResource.tf
+++ b/tests/content_security/crowdstrike_aidr/TestAccContentSecurityResource.tf
@@ -10,7 +10,7 @@ resource "aembit_content_security" "crowdstrike" {
 		encrypted_token = "test_token"
 		fail_open = true
 		max_retries = 10
-		timeout_ms = 3000
+		timeout_ms = 6000
 	}
 	tags = {
         color = "blue"

--- a/tests/content_security/data/TestAccContentSecurityDataSource.tf
+++ b/tests/content_security/data/TestAccContentSecurityDataSource.tf
@@ -10,7 +10,7 @@ resource "aembit_content_security" "crowdstrike" {
 		encrypted_token = "test_token"
 		fail_open = true
 		max_retries = 10
-		timeout_ms = 3000
+		timeout_ms = 6000
 	}
 }
 

--- a/tests/content_security/data/TestAccContentSecurityDataSource_ProviderResourceSet.tf
+++ b/tests/content_security/data/TestAccContentSecurityDataSource_ProviderResourceSet.tf
@@ -26,7 +26,7 @@ resource "aembit_content_security" "crowdstrike" {
 		encrypted_token = "test_token"
 		fail_open = true
 		max_retries = 10
-		timeout_ms = 3000
+		timeout_ms = 6000
 	}
 }
 

--- a/tests/content_security/data/TestAccContentSecurityDataSource_ResourceSet.tf
+++ b/tests/content_security/data/TestAccContentSecurityDataSource_ResourceSet.tf
@@ -23,7 +23,7 @@ resource "aembit_content_security" "crowdstrike" {
 		encrypted_token = "test_token"
 		fail_open = true
 		max_retries = 10
-		timeout_ms = 3000
+		timeout_ms = 6000
 	}
 }
 


### PR DESCRIPTION
### 📋 Summary

@github-copilot review

### 🔍 STP Plan
- **Situation**: Recent backend changes enforced a range validation on `TimeoutMs` (`[Range(5000, 600000)]`). Acceptance test fixtures in `terraform-provider-aembit` were hardcoded to `timeout_ms = 3000`, causing API `400 Bad Request` validation errors in CI.
- **Target**: Add client-side schema validation for `timeout_ms` (`Between(5000, 600000)`) and `max_retries` (`Between(0, 10)`), and update test fixtures and assertions to valid values (>= 5000 ms).
- **Proposal**:
  1. Add `int64validator.Between` range validators in `internal/provider/content_security_resource.go`.
  2. Update test fixtures in `tests/content_security/...` and `content_security_resource_test.go` from `3000` to `6000`.