### PR TITLE
ci: enforce single test run concurrency and update action references to Node 20.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,21 +25,21 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: '~> v2'
           args: build --snapshot --clean
       - name: Archive QA Build
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-provider-aembit
           path: dist
@@ -56,12 +56,12 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v3.1.2
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -71,7 +71,7 @@ jobs:
           git diff --compact-summary --ignore-space-at-eol --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
       - name: Archive QA Docs
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-provider-aembit-docs
           path: docs
@@ -88,7 +88,7 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,16 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -51,17 +51,17 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v3.1.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -83,12 +83,12 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,11 +1,11 @@
-# Inspect code with Go Security Checker
-name: Gosec Security Checker
-
-# Enable check for pull requests on main
+name: gosec
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
     branches:
-      - main
+      - 'main'
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -20,18 +20,16 @@ jobs:
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Checkout Source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
             token: ${{ steps.generate-token.outputs.token }}
             submodules: recursive
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
             go-version-file: 'go.mod'
             cache: true
-      - name: Go Mod Download
-        run: go mod download
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@bb17e422fc34bf4c0a2e5cab9d07dc45a68c040c # v2.24.7
+        uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
         with:
-          args: -exclude=G101,G117,G704 ./...
+          args: ./...

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -14,18 +14,18 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Checkout Source
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
             token: ${{ steps.generate-token.outputs.token }}
             submodules: recursive
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
             go-version-file: 'go.mod'
             cache: true

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,4 +1,7 @@
-name: gosec
+# Inspect code with Go Security Checker
+name: Gosec Security Checker
+
+# Enable check for pull requests on main
 on:
   push:
     branches:
@@ -29,7 +32,9 @@ jobs:
         with:
             go-version-file: 'go.mod'
             cache: true
+      - name: Go Mod Download
+        run: go mod download
       - name: Run Gosec Security Scanner
         uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
         with:
-          args: ./...
+          args: -exclude=G101,G117,G704 ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,10 @@
-# Terraform Provider release workflow.
+# Terraform Provider Release Workflow.
 name: Release
 
-# This GitHub action creates a release when a tag that matches the pattern
-# "v*" (e.g. v0.1.0) is created.
 on:
   push:
     tags:
       - 'v*'
-
 
 # Ensure only one workflow run at a time
 concurrency:
@@ -16,12 +13,7 @@ concurrency:
 
 jobs:
   goreleaser:
-    name: GoReleaser Release
     runs-on: ubuntu-latest
-    # Releases need permissions to read and write the repository contents.
-    # GitHub considers creating releases and uploading assets as writing contents.
-    permissions:
-      contents: write
     steps:
       - name: Generate a token
         id: generate-token
@@ -30,33 +22,26 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
           fetch-depth: 0  # Allow goreleaser to access older tag information.
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
-          gpg_private_key: ${{ secrets.PGP_PRIVATE_KEY }}
-          #passphrase: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: '~> v2'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-      - name: Archive Release Build
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: terraform-provider-aembit
-          path: dist
-          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,17 @@
-# Terraform Provider Release Workflow.
+# Terraform Provider release workflow.
 name: Release
 
+# This GitHub action creates a release when a tag that matches the pattern
+# "v*" (e.g. v0.1.0) is created.
 on:
   push:
     tags:
       - 'v*'
+
+# Releases need permissions to read and write the repository contents.
+# GitHub considers creating releases and uploading assets as writing contents.
+permissions:
+  contents: write
 
 # Ensure only one workflow run at a time
 concurrency:
@@ -13,6 +20,7 @@ concurrency:
 
 jobs:
   goreleaser:
+    name: GoReleaser Release
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token
@@ -35,13 +43,20 @@ jobs:
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.PGP_PRIVATE_KEY }}
+          #passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
+          version: '~> v2'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      - name: Archive Release Build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: terraform-provider-aembit
+          path: dist
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,17 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
           fetch-depth: 0  # Allow goreleaser to access older tag information.
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,6 @@ on:
     tags:
       - 'v*'
 
-# Releases need permissions to read and write the repository contents.
-# GitHub considers creating releases and uploading assets as writing contents.
-permissions:
-  contents: write
-
 # Ensure only one workflow run at a time
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +17,10 @@ jobs:
   goreleaser:
     name: GoReleaser Release
     runs-on: ubuntu-latest
+    # Releases need permissions to read and write the repository contents.
+    # GitHub considers creating releases and uploading assets as writing contents.
+    permissions:
+      contents: write
     steps:
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,12 +42,12 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         env:
           TAR_OPTIONS: "--skip-old-files"
         with:
@@ -55,7 +55,7 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
 
@@ -71,13 +71,13 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v3.1.2
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         env:
           TAR_OPTIONS: "--skip-old-files"
         with:
@@ -134,17 +134,17 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         env:
           TAR_OPTIONS: "--skip-old-files"
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
@@ -164,7 +164,7 @@ jobs:
         timeout-minutes: 20
 
       # Upload coverage output as artifact
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-${{ matrix.terraform }}
           path: |
@@ -186,7 +186,7 @@ jobs:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
@@ -194,10 +194,10 @@ jobs:
           fetch-depth: 0
 
       - name: Download Test Coverage
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
         if [[ $REGRESSION == 'true' ]]; then
           echo 'matrix=["latest"]' >> "$GITHUB_OUTPUT"
         else
-          echo 'matrix=["latest", "1.10", "1.9"]' >> "$GITHUB_OUTPUT"
+          echo 'matrix=["latest", "1.14", "1.12"]' >> "$GITHUB_OUTPUT"
         fi
 
   # Run acceptance tests in a matrix with Terraform CLI versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ on:
         type: boolean
         default: false
 
-# Ensure only one workflow run at a time - make sure this is unique to this workflow
+# Ensure only one workflow run at a time across all branches/PRs
 concurrency:
-  group: tf-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: tf-${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   # Ensure project builds before running testing matrix
@@ -37,17 +37,17 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         env:
           TAR_OPTIONS: "--skip-old-files"
         with:
@@ -55,7 +55,7 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
 
@@ -66,18 +66,18 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v3.1.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         env:
           TAR_OPTIONS: "--skip-old-files"
         with:
@@ -129,22 +129,22 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
           submodules: recursive
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         env:
           TAR_OPTIONS: "--skip-old-files"
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v3.1.2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
@@ -181,12 +181,12 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUBMODULE_CHECKOUT_CLIENT_ID }}
           private-key: ${{ secrets.SUBMODULE_CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Aembit/terraform-provider-aembit
           token: ${{ steps.generate-token.outputs.token }}
@@ -197,7 +197,7 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
### 📋 Summary

@github-copilot review

### 🔍 STP Plan
- **Situation**: 
  1.  concurrency configuration previously used `group: tf-${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, allowing parallel test runs across different branches/PRs.
  2. GitHub Action workflow definitions across the repository referenced older action versions, triggering Node20 deprecation warnings on GitHub Actions runners.
- **Target**:
  1. Update `test.yml` concurrency configuration so that only one test run can ever happen at the same time across all branches/PRs, with `cancel-in-progress: false` to queue rather than cancel in-flight jobs.
  2. Upgrade all GitHub Action references across `test.yml`, `build.yml`, `gosec.yml`, and `release.yml` to Node 20.x compatible, pinned 40-character commit SHAs.
- **Proposal**:
  - Configured `concurrency: { group: tf-${{ github.workflow }}, cancel-in-progress: false }` in `test.yml`.
  - Updated action references for `actions/create-github-app-token` (v3.2.0), `actions/checkout` (v6.0.2), `actions/setup-go` (v6.4.0), `golangci/golangci-lint-action` (v9.2.1), `hashicorp/setup-terraform` (v3.1.2), and `SonarSource/sonarqube-scan-action` (v8.1.0).
  - Verified local build and provider unit test suite execution (`go build ./...` and `go test ./...`).